### PR TITLE
统一 Release changelog 并补充性能评估

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,152 +1,183 @@
 # Changelog
 
-本文件记录用户可见变化、兼容边界和重要工程基线。中间迁移批次、Agent 工作记录、
-临时 APK 数据和低样本性能数字不作为 Release 历史。
+本文件记录公开版本的用户可见变化、兼容边界、验证结论和回退价值。内部迁移批次、
+Agent 工作记录、临时 APK 和未经同条件测量的性能数字不作为 Release changelog。
 
-## 公开 Release 保留策略
+## 当前公开版本
 
-GitHub Releases 仅保留 `r14.12.0`、`r14.8.0`、`r14.7.4` 和 `r14.5.0` 四个经过
-验证且具有独立回退价值的版本。Release 标题统一为纯版本号；已移除版本的资产信息和
-SHA-256 见 [历史 Release 归档](docs/RELEASE_ARCHIVE.md)，源码仍可由对应 Git tag
-和 commit 获取。
+| 版本 | 日期 | 定位 |
+| --- | --- | --- |
+| `r14.12.0` | 2026-07-26 | 当前稳定版；API 101/102、Kotlin、生命周期与构建治理 |
+| `r14.8.0` | 2026-07-25 | Kotlin 基础设施回退点 |
+| `r14.7.4` | 2026-07-25 | r14.7.x Kotlin/Coroutine 迁移合并版 |
+| `r14.5.0` | 2026-07-24 | 独立包名、签名和发布路径基线 |
+
+Release 标题统一为纯版本号。已移除版本的资产名、大小与 SHA-256 见
+[历史 Release 归档](docs/RELEASE_ARCHIVE.md)；对应源码仍可通过 Git tag 获取。
 
 ## [r14.12.0] - 2026-07-26
 
-### Compatibility
+### 版本定位
 
-- 维持 HyperOS 1 / Android 14、SDK 34 和 `arm64-v8a` 支持范围。
-- 同一 APK 以 libxposed API 101 为最低运行基线、API 102 为编译和目标版本。
-- 公共 Hook 路径只依赖 API 101 已存在的接口；API 102 专属 Hot Reload、hook ID 和
-  replacement 未启用。
-- 清除 Legacy `de.robv.android.xposed` 运行 API；设置入口 category 不属于 Legacy
-  API 调用。
+完成核心 Kotlin 迁移、生命周期与热路径治理，并以同一 APK 支持 libxposed API 101
+和 API 102。Android 支持范围保持 HyperOS 1 / Android 14。
 
-### Fixed
+### 主要变化
 
-- 修复应用选择页加载状态回归，避免恢复后持续显示加载态。
-- 分享和“打开方式”包列表改为常数时间去重，保持原有顺序和过滤语义。
-- 修复隐私应用和应用锁列表初始数据被重复加入的问题。
-- 收紧截图 DexKit 目标匹配，避免把相似但签名不符的方法作为 Hook 目标。
+- 使用 API 102 编译，`minApiVersion=101`、`targetApiVersion=102`、
+  `staticScope=false`。
+- 公共 Hook 路径只依赖 API 101 已有接口；未启用 Hot Reload、hook ID 和原子
+  replacement。
+- 核心 Hook、设置 UI 和工具代码完成保守 Kotlin 迁移，保留 `MainModule.java`、
+  libxposed 兼容层及必要 JVM 反射边界。
+- 修复应用选择页加载状态、分享/打开方式去重、隐私应用和应用锁重复数据。
+- 收紧截图 DexKit 目标匹配，避免 Hook 到签名不符的方法。
 
-### Lifecycle
+### 生命周期与性能
 
-- `AudioVisualizer` 的 Observer、Coroutine、动画和原生 `Visualizer` 资源现在随 owner
-  结束而取消或释放。
-- `BatteryIndicator` 在 View detach 后解除 Receiver/Observer、回调和绘制资源。
-- 音量面板模糊 Observer 只注册一次，避免 SystemUI 重建后的重复通知。
-- 截图期间状态栏和导航栏 Receiver 绑定到 View attach/detach 生命周期。
-- 锁屏专辑封面 Receiver 使用单一注册和弱目标，避免重建后的重复回调和静态 View 持有。
-- SystemUI 长期对象的重复 Hook、重复初始化和功能关闭后的残留任务经过集中审计。
+- `AudioVisualizer` 的 Observer、Coroutine、动画和原生 `Visualizer` 随 owner 释放。
+- `BatteryIndicator` detach 后注销 Receiver/Observer 和绘制回调。
+- 音量模糊、截图栏隐藏和锁屏专辑封面监听在 SystemUI 重建后不重复注册。
+- 双排信号、定时振动和 Launcher 图标缩放热路径减少临时对象、格式化和资源读取。
+- 反射、DexKit 和资源探测保留在初始化路径；未引入轮询、永久后台任务或大型抽象层。
+- 功能关闭时尽量不注册对应 Hook 和长期监听。
 
-### Performance
+### 构建与依赖
 
-- 双排移动信号绘制减少临时对象和重复状态计算。
-- 定时振动区间判断移除热路径格式化和不必要数学运算。
-- Launcher 图标缩放缓存稳定输入，减少重复资源读取。
-- 反射、DexKit 和资源查找保留在初始化或冷路径；未引入轮询、永久后台任务或大型抽象层。
+- Groovy 构建脚本迁移到 Kotlin DSL，直接依赖集中到 version catalog。
+- Gradle Wrapper 9.6.1、Android Gradle Plugin 9.2.1、Kotlin BOM 2.3.21。
+- kotlinx.coroutines 1.11.0、libxposed API/service 102.0.0。
+- Release 启用 R8、资源压缩、zipalign 和 APK Signature Scheme v2。
 
-### Kotlin and Architecture
+### 验证
 
-- 核心 Hook、设置 UI 和工具代码完成保守 Kotlin 迁移。
-- 保留 `MainModule.java`、现代 libxposed 兼容层和局部 JVM 反射实现等必要 Java 边界。
-- 修正无收益的 `inline`，检查 nullability、JVM 签名、初始化顺序及 R8 可达性。
-- 未为形式统一引入 Flow、Sequence、DSL、新架构层或无所有者协程。
+- 单元测试、Debug、Release、Lint、`lintRelease`、`lintVitalRelease` 通过。
+- API 101 依赖回编译、API 102 正式构建、Legacy Xposed API 扫描通过。
+- APK 入口、scope、`module.prop`、签名和 zip alignment 已检查。
+- API 101 实机完成安装、整机重启和完整 `full.log` 审计，未发现模块相关崩溃、ANR、
+  入口、Hook 或 API 链接错误。
 
-### Build and Dependencies
-
-- Groovy 构建脚本迁移为 Kotlin DSL，直接依赖集中到 version catalog。
-- Gradle Wrapper 更新到 9.6.1，并固定发行 ZIP 的 SHA-256。
-- Android Gradle Plugin 保持 9.2.1；Kotlin BOM 更新到 2.3.21。
-- kotlinx.coroutines 更新到 1.11.0；libxposed API/service 使用 102.0.0。
-- Release 继续启用 R8、resource shrink、zipalign 和 APK Signature Scheme v2。
-
-### Verification
-
-- 单元测试、Debug、Release、Lint、`lintRelease`、R8、资源压缩和签名检查通过。
-- 使用 API 101 依赖回编译通过，恢复 API 102 依赖后的完整构建通过。
-- APK 的 Xposed 入口、scope、`module.prop`、签名和 zip alignment 已检查。
-- 最终代码基线已完成手机安装、整机重启和基础 LSPosed/Vector 日志检查，未发现阻止发布的
-  模块崩溃、ANR 或入口加载错误。
-- Release 资产仍以用户实际安装确认的精确 APK SHA-256 为准；不同构建不得替换已验证资产。
-
-### Known Limits
+### 已知限制
 
 - 仅支持 HyperOS 1 / Android 14 和 `arm64-v8a`。
-- API 101 管理器可能因 `targetApiVersion=102` 显示较新版本提示；该提示不等同于加载失败。
-- Hot Reload 未启用，也未验证热卸载或 Hook 原子替换。
+- API 102 实机仍需在对应框架环境独立验证。
+- Hot Reload 未启用。
 - 厂商系统应用更新可能改变 Hook 目标。
-- API 101 实机完整 `full.log` 已审计，未发现可归因于模块的运行错误；API 102 实机仍需
-  在对应框架环境独立验证。
-
-## [r14.10.0] - 2026-07-26
-
-### Summary
-
-- 建立 libxposed API 101 / API 102 单 APK 双兼容基线。
-- 构建脚本迁移到 Kotlin DSL，并用 version catalog 固定直接依赖。
-- Android 运行范围保持 SDK 34，没有把 libxposed API 版本与 Android SDK 混淆。
-
-### Compatibility
-
-- `minApiVersion=101`、`targetApiVersion=102`、`staticScope=false`。
-- 使用 API/service 102 编译，公共运行路径不引用 API 102 专属类型。
-- 保持既有 Hook priority、before/after、参数修改、异常传播和 unhook 语义。
-
-### Verification
-
-- API 101 依赖回编译、API 102 Release、R8、资源压缩和 Legacy API 扫描通过。
-- 该版本是 Git 兼容里程碑；若未形成同签名、可下载的正式 Release，不作为公开回退空壳保留。
 
 ## [r14.8.0] - 2026-07-25
 
-### Summary
+### 版本定位
 
-- 建立核心现代化前的 Kotlin 基础设施稳定基线。
-- 完成设置 UI、工具类、部分 Hook 和 Coroutine 的保守迁移。
-- 替换不必要的 hidden API 使用，并继续清理 lint、死代码和废弃资源。
+建立核心 mods 大规模 Kotlin 化之前的基础设施稳定点，用于区分后续 Hook 迁移问题与
+工具层问题。
 
-### Verification
+### 主要变化
 
-- 通过当时的 Debug/Release、R8、Lint 和签名检查。
-- 保留为排除后续核心 Hook 与 API 兼容改动影响的回退点。
+- `Helpers`、`AppHelper`、`ModuleHelper`、`HookerClassHelper`、`ResourceHooks`、
+  `ShakeManager` 和 `ResourceConstants` 保守迁移到 Kotlin。
+- `AppHelperTest`、`PrefMapTest`、`XposedHelpersCacheTest` 迁移到 Kotlin。
+- 保持 Java/Kotlin 静态互操作、反射入口、Hook priority 和异常传播语义。
+- 修复 `MainFragment`、`SpinnerEx`、`SortableListView` 和 Intent flags 的 Lint 问题。
+- 清理旧 APK、临时构建日志和无用产物。
+
+### 验证
+
+- versionCode 170 / versionName `r14.8.0`。
+- 单元测试、编译、Release、R8、Lint 和签名检查通过。
+- 完整重启日志中模块加载成功，未发现模块相关崩溃或 ANR。
+
+### 回退价值
+
+保留为核心 Hook Kotlin 化、API 101/102 改造和后续生命周期治理之前的基础设施对照点。
 
 ## [r14.7.4] - 2026-07-25
 
-### Summary
+### 版本定位
 
-- 合并 r14.7.x 的 Kotlin/Coroutine 迁移与设置界面整理。
-- 保留迁移前后可比较的独立包名和发布路径。
+合并 r14.7.0–r14.7.3 的 Coroutine、设置子页面、UI 控件和小型工具迁移，作为 r14.7.x
+唯一公开稳定版。
 
-### Why It Is Retained
+### 主要变化
 
-- APK、SHA-256、签名连续性和完整重启记录均已归档。
-- 作为 r14.7.x Kotlin/Coroutine 迁移合并版保留，可与 r14.8.0 基础设施迁移版及
-  r14.5.0 独立包名基线分层对照。
+- `BitmapCachedLoader`、天气、步数、音频可视化和电池指示器迁移到有生命周期的
+  Kotlin Coroutine。
+- Activity/App 选择器、搜索子页面和设置 Fragment 使用 lifecycle scope。
+- 列表 Adapter 引入 ViewHolder，偏好控件和小型设置页迁移到 Kotlin。
+- 动画缩放改用 `Settings.Global` 公共 API，并保留必要回退。
+- 清理废弃构建产物、旧 APK 和临时日志。
 
-## Historical Consolidation
+### 验证
+
+- versionCode 169 / versionName `r14.7.4`。
+- Release 构建和 `lintVitalRelease` 通过。
+- 完整重启日志中入口加载成功，未发现模块相关崩溃或 ANR。
+- APK SHA-256：
+  `1B2026B6FFAEE33C3BE50E4695EE8BF19EAA6740124A199153D89C63251F2329`。
+
+### 回退价值
+
+保留为 r14.7.x Coroutine/UI 迁移合并点，可与 r14.8.0 工具基础设施版分层对照。
+
+## [r14.5.0] - 2026-07-24
+
+### 版本定位
+
+建立当前独立包名、签名与 GitHub 发布路径，是后续 Kotlin 和 API 改造的长期回退基线。
+
+### 主要变化
+
+- 源码包迁移到 `tv.withaibuild.customiuizer`。
+- namespace 使用 `tv.withaibuild.customiuizer`，applicationId 使用
+  `tv.withaibuild.customiuizer.r14`。
+- Manifest、XML、Preference、Shortcut、Tasker 组件和 R8 规则同步更新。
+- 为数字格式和大小写比较指定稳定 Locale。
+- UI 设置重置由同步 `commit()` 改为 `apply()`。
+- Handler 显式绑定主线程 Looper，动态 Receiver 补全 Android 14 导出标志。
+- 高频 `Resources.getIdentifier()` 收敛到线程安全的资源 ID 缓存。
+
+### 验证
+
+- versionCode 150 / versionName `r14.5.0`。
+- `assembleRelease`、`lintVitalRelease` 和签名检查通过。
+- 完整重启后未发现模块相关崩溃、ANR 或异常栈。
+- APK SHA-256：
+  `DCB9EBC4BBE7AEE721B58F83B5371E1030AD7CAB0C4FE6CC4EAD900C420E8C93`。
+
+### 回退价值
+
+当前包名与签名线的最早公开稳定点。更早版本包名或工程结构不同，不适合作为普通用户
+回退版本。
+
+## 非公开工程里程碑
+
+### r14.10.0
+
+- 建立 libxposed API 101/102 单 APK 兼容边界。
+- 构建脚本迁移到 Kotlin DSL，并用 version catalog 固定直接依赖。
+- 完成 API 101 依赖回编译、API 102 Release、R8、资源压缩和 Legacy API 扫描。
+- 该版本未作为当前公开回退 Release 保留，其成果已经合并到 r14.12.0。
+
+## 历史阶段
 
 ### r14.0–r14.3
 
-- 建立 HyperOS 1 / Android 14 独立维护版本线。
-- 完成早期资源和反射缓存、功能关闭时的无效 Hook 减少，以及状态栏和绘制热路径整理。
+- 建立 HyperOS 1 / Android 14 和现代 libxposed API 101 独立维护线。
+- 完成早期资源、反射、状态栏绘制和无效 Hook 优化。
 
 ### r14.5–r14.6
 
-- 迁移到当前独立包名和签名发布路径。
-- 推进生命周期、资源查找、代码拆分、R8 与测试基础，并修复关键兼容问题。
+- 建立当前独立包名、签名和发布路径。
+- 推进生命周期、双排信号、资源查找、R8 和测试治理。
 
 ### r14.7–r14.8
 
-- 推进 Kotlin/Coroutine、设置 UI 和工具类迁移。
-- 替换部分 hidden API，持续处理 Lint、死代码和构建可重复性。
+- 推进 Coroutine、设置 UI、工具类和基础设施 Kotlin 迁移。
+- 清理 hidden API、Lint、死代码和废弃资源。
 
 ### r14.9–r14.12
 
 - 完成核心 Hook 的保守 Kotlin 化和 Kotlin/JVM 边界复核。
-- 建立 API 101/102 单 APK 兼容以及 Kotlin DSL/version catalog 构建。
-- 完成生命周期、重复注册、热路径、逻辑、设置 UI、依赖和工具链的系统审计。
-- 通过完整构建门禁和最终代码基线的手机重启、基础日志检查。
+- 建立 API 101/102 单 APK 兼容、Kotlin DSL 与 version catalog。
+- 完成生命周期、重复注册、热路径、设置 UI、依赖和工具链审计。
 
-更细的中间变化仍可从 Git commit 历史追溯，但不再为每个开发批次保留独立 Release
-章节。曾公开但现已移除的 Release 资产校验信息见
-[历史 Release 归档](docs/RELEASE_ARCHIVE.md)。
+更细的提交历史可由 Git tag 和 commit 追溯，不再为每个内部批次创建公开 Release。

--- a/README.md
+++ b/README.md
@@ -2,132 +2,118 @@
 
 面向 HyperOS 1 / Android 14 的 CustoMIUIzer 独立维护版。
 
-本项目是 CustoMIUIzer 的独立维护版本。Android 14 功能语义以
+本项目以
 [MonwF/customiuizer v24.10.12](https://github.com/MonwF/customiuizer/releases/tag/v24.10.12)
-为参考，但本项目不是 MonwF 的官方发布，并使用独立包名、版本线、构建、签名和发布流程。
+作为 Android 14 功能语义参考，但使用独立包名、版本线、签名、现代 libxposed API 和
+发布流程，不是上游官方版本。
 
-目标平台仅为 HyperOS 1 / Android 14。项目不承诺 Android 15、Android 16 或其他
-MIUI/HyperOS 版本的兼容性。
+## 当前版本
 
-## 当前稳定状态
-
-| 项目 | 当前状态 |
+| 项目 | 状态 |
 | --- | --- |
 | 稳定版本 | `r14.12.0` |
-| Android | Android 14 / SDK 34 |
-| ROM | HyperOS 1 |
+| 支持系统 | HyperOS 1 / Android 14（SDK 34） |
 | ABI | `arm64-v8a` |
-| 包名 | `tv.withaibuild.customiuizer.r14` |
-| Xposed API | min 101 / target 102 |
+| applicationId | `tv.withaibuild.customiuizer.r14` |
+| libxposed API | min 101 / target 102 |
 | Hot Reload | 关闭 |
-| 构建 | Kotlin DSL / version catalog |
-| 最新下载 | [r14.12.0](https://github.com/tomthenpc/customiuizer-a14/releases/tag/r14.12.0) |
+| 构建 | Kotlin DSL / version catalog / R8 |
+| 下载 | [GitHub Release](https://github.com/tomthenpc/customiuizer-a14/releases/tag/r14.12.0) |
 
-`r14.12.0` 是当前现代化、Kotlin 迁移、生命周期治理和 API 101/102 单 APK
-兼容工作的稳定基线。发布 APK 已完成 API 101 实机安装、整机重启和完整 `full.log`
-审计，未发现可归因于模块的崩溃、ANR、入口、Hook 或 API 链接错误。API 102 的构建
-兼容已经验证，API 102 实机运行仍需在对应框架环境独立确认。
+## r14.12.0 亮点
 
-## 下载
+- **API 101/102 单 APK 双兼容**：以 API 102 编译，API 101 作为最低运行基线。
+- **保守 Kotlin 化**：核心 Hook、设置 UI 和工具代码迁移到 Kotlin，保留必要 Java/JVM
+  入口和反射边界。
+- **生命周期治理**：SystemUI 重建时避免重复 Hook、Receiver、Observer、Listener、
+  Coroutine 和动画任务。
+- **热路径收敛**：反射、DexKit 和资源查找移到初始化路径，绘制与高频回调减少临时对象、
+  重复格式化和重复状态计算。
+- **功能关闭低成本**：不需要的功能尽量不注册 Hook 或长期监听，不增加轮询和永久后台任务。
+- **可复现发布**：固定 Gradle 与直接依赖版本，Release 启用 R8、资源压缩、zipalign 和
+  APK Signature Scheme v2。
 
-- 最新稳定版：[r14.12.0](https://github.com/tomthenpc/customiuizer-a14/releases/tag/r14.12.0)
+## 下载与校验
+
 - APK：`CustoMIUIzer-A14-r14.12.0.apk`
+- 大小：3,020,253 bytes
 - SHA-256：`7E488C4ED011F68321A8A2E5911B61D1C35659C98CA0116500855F79F05ED80E`
-- applicationId：`tv.withaibuild.customiuizer.r14`
+- 签名证书 SHA-256：`3061A3DA1C2FC46B44E215D024B1BFE3A012CB4D70B90B0214FA9FC896CEF60D`
 
-仅从本仓库 Releases 下载。不同签名的 APK 可能无法覆盖安装，处理旧安装前请先备份设置。
-
-## 与上游 v24.10.12 的差异
-
-| 维度 | 本项目 | 上游 v24.10.12 |
-| --- | --- | --- |
-| 定位 | 独立 Android 14 维护线 | Android 14 功能参考基线 |
-| 包名和版本 | 独立包名与 `r14.x` 版本线 | 上游原始包名与版本线 |
-| Xposed API | libxposed API 101/102 单 APK 兼容 | libxposed API 100 |
-| Kotlin | Kotlin-first，保留必要 Java/JVM 边界 | 以 Java 为主 |
-| 构建 | Kotlin DSL、version catalog、Gradle 9 | Groovy DSL |
-| 生命周期 | 明确 Receiver、Observer、Listener 和 Coroutine owner | 保留上游实现 |
-| Hook | 防重复注册，并区分冷路径与热路径成本 | 保留上游实现 |
-| Release | R8、资源压缩、签名和 APK 元数据检查 | 上游独立发布流程 |
-| 验证 | 单测、Lint、Debug/Release、API 回编译和实机门禁 | 上游独立验证流程 |
-
-主要功能来自上游 Android 14 功能基线。本项目的工作重点是独立维护、现代 libxposed
-兼容、已确认缺陷修复、生命周期约束、构建治理和可复现发布，不把上游功能重新描述为
-本项目原创。
-
-## 支持范围
-
-- 仅支持 HyperOS 1 / Android 14（SDK 34）。
-- 仅提供 `arm64-v8a` 构建。
-- 框架必须实现 libxposed API 101 或 API 102。
-- 推荐使用支持现代 libxposed API 的 LSPosed/Vector 构建。
-- 不支持 Android 15、Android 16，也不保证其他 MIUI/HyperOS 版本。
-- 不得与上游版或其他 CustoMIUIzer 派生模块同时启用。
-- 不同签名的 APK 可能无法覆盖安装；卸载前应先备份配置。
-- 系统应用版本和厂商 ROM 差异仍可能影响个别 Hook。
-
-模块声明 `targetApiVersion=102`。在 API 101 框架中，管理器可能提示模块“为较新的
-Xposed 版本设计”；这是目标 API 的版本比较结果，不等同于模块加载失败。应以框架日志、
-目标进程状态和实际功能行为为准。
+仅从本项目 Release 或对应的 LSPosed 模块仓库下载。不同签名可能无法覆盖安装，处理旧
+安装前请先备份设置。
 
 ## 功能范围
 
-项目保留上游 Android 14 基线中的主要定制能力，按运行区域可概括为：
+- 状态栏、图标、电池、信号、网速、日期和温度；
+- 控制中心、音量面板、亮度与通知行为；
+- 锁屏、充电信息、媒体界面和快捷操作；
+- Launcher、最近任务、文件夹、图标和桌面手势；
+- 导航栏、按键、自定义动作、电源菜单和系统动画；
+- 应用、权限、安装、分享、隐私应用和应用锁行为。
 
-- SystemUI、状态栏和图标；
-- 控制中心、音量面板和通知；
-- 锁屏、充电信息和媒体界面；
-- Launcher、最近任务和桌面行为；
-- 全局手势、按键动作和电源菜单；
-- 应用、权限、安装和分享行为；
-- 其他 HyperOS 系统界面定制。
+具体功能是否可用仍取决于 ROM 与系统应用版本。厂商更新可能改变 Hook 目标。
 
-具体功能是否可用取决于 ROM 和系统应用版本。出现问题时应同时记录模块版本、框架 API、
-设备完整重启后的日志和目标应用版本。
+## 理论性能与省电评估
 
-## 工程差异
+模块运行在 SystemUI、Launcher 和 `system_server` 等长驻进程中，额外成本主要取决于：
 
-- 大部分业务和 Hook 实现已迁移到 Kotlin；稳定的入口、反射和 JVM 兼容边界保留 Java。
-- 使用 API 102 编译，同时以 API 101 为最低运行基线。
-- API 102 专属 Hot Reload、hook ID 和 replacement 当前未进入运行路径。
-- Receiver、Observer、Listener、Handler、动画和 CoroutineScope 绑定明确生命周期。
-- SystemUI 重建路径避免重复 Hook、重复注册和静态 View/Context 长期持有。
-- 对反射、DexKit、资源查找和稳定输入进行冷路径缓存。
-- 高频 Hook 回调减少临时数组、集合、格式化和重复状态计算。
-- Release 启用 R8、资源压缩、zipalign 和 APK Signature Scheme v2。
-- Gradle Wrapper 和直接依赖版本均固定；依赖集中在 version catalog。
+> 触发频率 × 单次成本 × 进程数量 × 存活时间
 
-详细兼容边界见
+下表是相对于上游或早期 r14 实现的**代码路径理论评估**，不是实验室功耗跑分：
+
+| 场景 | 早期实现风险 | 当前处理 | 理论影响 |
+| --- | --- | --- | --- |
+| 功能关闭 | Hook 或监听仍可能进入回调 | 按开关和进程决定是否注册 | 降低无效 Hook 分发与常驻开销 |
+| SystemUI 重建 | Receiver/Observer/任务可能重复 | 注册幂等，资源随 owner detach | 降低重复回调、泄漏和后台工作 |
+| 绘制与动画 | 重复资源查找、格式化、临时对象 | 冷路径缓存，热路径复用状态 | 降低 CPU、分配和 GC 压力 |
+| 音频与周期事件 | 任务所有权不清或重复调度 | 生命周期取消，优先响应系统事件 | 降低空唤醒与残留任务概率 |
+| 设置列表 | 重复遍历、过滤和去重 | 使用稳定缓存和常数时间去重 | 降低页面加载时的主线程工作 |
+| 兼容失败 | 重复反射探测或日志刷屏 | 冷路径探测，单项安全停用 | 降低异常重试和重启风暴风险 |
+
+理论上，收益最明显的场景是：关闭大量功能、SystemUI 多次重建、长时间待机，以及频繁
+触发状态栏/控制中心绘制。省电潜力主要来自减少无效回调、线程调度、轮询、重复注册和
+异常重试，而不是代码行数变少。
+
+项目没有宣称固定的续航、CPU 或内存提升百分比。实际收益会受启用功能、ROM、框架、
+使用习惯和系统应用版本影响，需要在同设备、同设置下用 Perfetto、Batterystats 和
+内存工具对照测量。
+
+## 兼容范围
+
+- 仅支持 HyperOS 1 / Android 14（SDK 34）和 `arm64-v8a`。
+- 框架必须实现现代 libxposed API 101 或 API 102。
+- 不支持 Android 15、Android 16，也不保证其他 MIUI/HyperOS 版本。
+- 不要与上游版或其他 CustoMIUIzer 派生模块同时启用。
+- `targetApiVersion=102` 在 API 101 管理器中可能显示“面向较新 API”的提示；应以实际
+  加载日志和功能行为判断，不把提示本身当作错误。
+- API 102 Hot Reload、hook ID 和原子 replacement 当前未启用。
+
+完整边界见
 [libxposed API 101/102 双兼容说明](docs/LIBXPOSED_API_101_102_COMPATIBILITY.md)。
 
-## 安装和升级
+## 安装
 
-1. 从 [Latest Release](https://github.com/tomthenpc/customiuizer-a14/releases/latest) 下载 APK。
-2. 安装 APK；如签名不同导致无法覆盖，先备份设置再处理旧安装。
-3. 在 LSPosed/Vector 中启用模块并检查作用域。
-4. 打开模块设置一次。
-5. 完整重启设备，不以单独重启应用代替。
-6. 检查模块、`system_server`、SystemUI 和 Launcher 日志及常用功能。
+1. 下载并安装 APK。
+2. 在 LSPosed/Vector 中启用模块并确认推荐作用域。
+3. 打开模块设置一次。
+4. 完整重启设备。
+5. 检查 `system_server`、SystemUI、Launcher 和常用功能。
 
-旧包名版本不会自动迁移为当前独立包名。升级前不要同时启用两个同源模块。
+旧包名版本不会自动迁移到当前独立包名。卸载旧模块前请先备份配置。
 
-## Release 验证
+## 验证状态
 
-稳定 Release 的静态和构建门禁包括：
+- 单元测试、Debug/Release、Lint、`lintRelease`、`lintVitalRelease` 通过；
+- R8、资源压缩、zipalign、v2 签名与 APK 元数据通过；
+- API 101 依赖回编译与 API 102 正式构建通过；
+- API 101 实机完成安装、整机重启和完整 `full.log` 审计；
+- 未发现可归因于模块的崩溃、ANR、入口、Hook 或 API 链接错误；
+- API 102 实机运行仍需在对应框架环境独立验证。
 
-- unit tests；
-- Debug 和 Release 构建；
-- Lint、`lintRelease` 和 `lintVitalRelease`；
-- R8 和 resource shrink；
-- signing 与 zipalign；
-- APK 内 Xposed 入口、scope 和 `module.prop`；
-- Legacy `de.robv.android.xposed` API 扫描；
-- API 101 依赖回编译和 API 102 正式构建；
-- 设备完整重启和基础 LSPosed/Vector 日志检查。
+构建成功只证明静态和产物边界，不替代不同 ROM、框架与功能组合的实机测试。
 
-构建通过只能证明产物和静态兼容边界，不代替 API 101、API 102 各自的实机功能验证。
-
-## 构建
+## 开发与构建
 
 需要 JDK 17 和 Android SDK：
 
@@ -136,40 +122,47 @@ Xposed 版本设计”；这是目标 API 的版本比较结果，不等同于�
 .\gradlew.bat --no-daemon clean test lint lintRelease lintVitalRelease assembleRelease
 ```
 
-正式签名配置位于仓库外部的 `../keystore.properties`，不得提交 keystore、密码或本地
-构建状态。
+签名配置位于仓库外部的 `../keystore.properties`。不得提交 keystore、密码、日志、缓存
+或本地构建状态。
 
-## 版本策略
+工程方法和来源说明：
 
-- `r14.x` 是 Android 14 独立维护版本线。
-- `r14.12.0` 是当前 minor 的初始稳定基线。
-- `r14.12.x` 只承载日志归因明确的兼容性、崩溃、生命周期和小范围行为修复。
-- 新功能或重大架构变化进入新的 minor 版本。
-- 纯文档变更不单独发布补丁版本，也不为每个 commit 创建 Release。
-- GitHub Releases 固定只保留 4 个关键版本。
-- Release 标题只使用版本号，并与 tag、`versionName` 保持一致，例如 `r14.12.0`。
-- 未保留版本继续存在于 [CHANGELOG](CHANGELOG.md)、[历史 Release 归档](docs/RELEASE_ARCHIVE.md)
-  和 Git tag/commit 历史中。
+- [CHANGELOG](CHANGELOG.md)
+- [项目谱系](docs/PROJECT_LINEAGE.md)
+- [工程方法](docs/ENGINEERING_METHOD.md)
+- [历史 Release 归档](docs/RELEASE_ARCHIVE.md)
 
-当前公开 Release：
+## 与上游的区别
+
+| 维度 | 本项目 | 上游参考 |
+| --- | --- | --- |
+| 定位 | HyperOS 1 / Android 14 独立维护线 | Android 14 功能语义参考 |
+| 包名 | `tv.withaibuild.customiuizer.r14` | 上游包名 |
+| Xposed API | 现代 API 101/102 单 APK | v24.10.12 使用 API 100 |
+| 实现 | Kotlin-first，保留稳定 JVM 边界 | 以 Java 为主 |
+| 生命周期 | 显式 owner、注销和防重复 | 保留上游实现 |
+| 构建 | Kotlin DSL、version catalog、R8 | 上游独立流程 |
+
+上游只用于核对功能原意和历史 Hook 行为，不会用旧代码覆盖当前 Kotlin/API 101/102
+实现。
+
+## Release 策略
+
+公开 Release 固定保留四个关键版本：
 
 | 版本 | 定位 |
 | --- | --- |
-| [r14.12.0](https://github.com/tomthenpc/customiuizer-a14/releases/tag/r14.12.0) | 当前稳定版；Kotlin、生命周期治理、API 101/102 单 APK 兼容 |
-| [r14.8.0](https://github.com/tomthenpc/customiuizer-a14/releases/tag/r14.8.0) | 核心现代化前的 Kotlin 基础设施回退点 |
-| [r14.7.4](https://github.com/tomthenpc/customiuizer-a14/releases/tag/r14.7.4) | r14.7.x Kotlin/Coroutine 迁移合并版 |
-| [r14.5.0](https://github.com/tomthenpc/customiuizer-a14/releases/tag/r14.5.0) | 独立包名、签名和发布路径的长期回退基线 |
+| `r14.12.0` | 当前稳定版 |
+| `r14.8.0` | Kotlin 基础设施回退点 |
+| `r14.7.4` | r14.7.x Kotlin/Coroutine 合并版 |
+| `r14.5.0` | 独立包名、签名与发布路径基线 |
 
-发布新版本时，应在以上四类中保留最有验证价值的四个版本；删除旧 Release 前先在
-`docs/RELEASE_ARCHIVE.md` 保存版本说明、资产名、大小和 SHA-256。删除 Release 不删除
-对应 Git tag。
+Release 标题只使用版本号。其余版本保留于 CHANGELOG、历史归档和 Git tag 中。
 
-## 上游、许可证和致谢
+## 许可证与致谢
 
 项目派生自 Mikanoshi/CustoMIUIzer，并参考
 [MonwF/customiuizer](https://github.com/MonwF/customiuizer) 的 Android 14 工作。
-感谢 LSPosed/libxposed、DexKit 及相关开源项目的维护者。
+感谢 LSPosed/libxposed、DexKit 及相关开源项目维护者。
 
-本项目依据 [GPL-3.0](LICENSE) 分发。二进制发布必须提供对应源代码，保留版权和许可证
-声明，并明确标识修改。来源和独立维护关系见 [NOTICE.md](NOTICE.md) 与
-[项目谱系](docs/PROJECT_LINEAGE.md)。
+本项目依据 [GPL-3.0](LICENSE) 分发。来源和独立维护关系见 [NOTICE.md](NOTICE.md)。


### PR DESCRIPTION
## 内容

- 将四个公开 Release 的 changelog 统一为版本定位、主要变化、验证和回退价值/限制格式
- 精简 README，突出 r14.12.0 新特性、兼容范围与下载校验
- 增加基于代码路径的理论性能和省电对比，明确不宣称未经测量的固定百分比
- 保留 API 102 实机验证边界

## 范围

仅文档；不修改业务源码、构建配置或发布 APK。
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tomthenpc/customiuizer-a14/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->