### PR TITLE
fix: let the bind-decision budget, not the caller, decide

### DIFF
--- a/app/src/main/java/tv/withaibuild/customiuizer/MainFragment.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/MainFragment.kt
@@ -25,8 +25,6 @@ import androidx.recyclerview.widget.RecyclerView
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -44,17 +42,6 @@ import tv.withaibuild.customiuizer.utils.SearchStateMachine
 import tv.withaibuild.customiuizer.utils.XposedServiceManager
 
 class MainFragment : PreferenceFragmentBase() {
-
-    private companion object {
-        /**
-         * Total time this screen waits for a decided bind state before it is willing to
-         * say the module is not active. Two of the service manager's own windows plus a
-         * margin: the first covers an ordinary start, the second covers a bind that is
-         * still in flight after a process restart.
-         */
-        const val MODULE_DECISION_BUDGET_MS =
-            XposedServiceManager.BIND_DECISION_TIMEOUT_MS * 2 + 500L
-    }
 
     private val catSelector = CategorySelector()
 
@@ -115,41 +102,20 @@ class MainFragment : PreferenceFragmentBase() {
 
     private fun checkModuleIsActive() {
         lifecycleScope.launch {
-            // Keep waiting across the service manager's own deadline. A timeout is not
+            // Keep waiting across the service manager's own bind deadline. A timeout is not
             // proof - only onServiceDied is - and the bind is slowest right after this
             // process was restarted, which is exactly when the user is looking at this
             // screen. The previous code stopped waiting as soon as the state left UNKNOWN,
             // so entering TIMED_OUT ended the wait immediately and was then read as a
             // negative; a language change, which kills and relaunches this process, made
             // that race visible as an intermittent "module not active".
-            if (!awaitDecision(MODULE_DECISION_BUDGET_MS)) return@launch
+            if (!awaitBindDecision()) return@launch
 
             val act = activity as? AppCompatActivity ?: return@launch
-            // The budget is spent, so a still-pending bind now counts as a negative -
-            // otherwise a genuinely inactive module would never be reported.
-            if (isFragmentReady(act) &&
-                XposedServiceManager.shouldReportInactive(bindStillPending = true)
-            ) {
+            if (isFragmentReady(act) && XposedServiceManager.shouldReportInactive()) {
                 showXposedDialog(act)
             }
         }
-    }
-
-    /**
-     * Waits up to [timeoutMs] for the service state to stop being provisional, i.e. to
-     * become BOUND or DISCONNECTED. UNKNOWN and TIMED_OUT are both provisional.
-     *
-     * Returns false if the coroutine was cancelled, in which case the caller must stop.
-     */
-    private suspend fun awaitDecision(timeoutMs: Long): Boolean {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (XposedServiceManager.state.isProvisional &&
-            System.currentTimeMillis() < deadline
-        ) {
-            if (!coroutineContext.isActive) return false
-            delay(100L)
-        }
-        return coroutineContext.isActive
     }
 
     override fun onCreatePreferences(@Nullable savedInstanceState: Bundle?, @Nullable rootKey: String?) {

--- a/app/src/main/java/tv/withaibuild/customiuizer/PreferenceFragmentBase.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/PreferenceFragmentBase.kt
@@ -33,6 +33,9 @@ import java.util.Date
 import java.util.HashMap
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.coroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import tv.withaibuild.customiuizer.mods.GlobalActions
@@ -122,23 +125,7 @@ open class PreferenceFragmentBase : PreferenceFragmentCompat() {
                 return true
             }
             R.id.softreboot -> {
-                // Not `!AppHelper.moduleActive`: that flag is also false while the bind is
-                // merely still pending, so tapping this shortly after a process start
-                // claimed the module was inactive when nothing had been observed yet.
-                if (XposedServiceManager.shouldReportInactive(bindStillPending = true)) {
-                    showXposedDialog(activity as AppCompatActivity?)
-                    return true
-                }
-                AlertDialog.Builder(getValidContext())
-                    .setTitle(R.string.soft_reboot)
-                    .setMessage(R.string.soft_reboot_ask)
-                    .setPositiveButton(android.R.string.ok) { _, _ ->
-                        val intent = Intent(GlobalActions.ACTION_PREFIX + "FastReboot")
-                        intent.setPackage("com.android.systemui")
-                        getValidContext().sendBroadcast(intent)
-                    }
-                    .setNegativeButton(android.R.string.cancel) { _, _ -> }
-                    .show()
+                confirmSoftReboot()
                 return true
             }
             R.id.about -> {
@@ -156,11 +143,65 @@ open class PreferenceFragmentBase : PreferenceFragmentCompat() {
         return false
     }
 
+    /**
+     * Waits until the bind state can no longer change the answer, i.e. the service bound,
+     * died, or [XposedServiceManager.FULL_DECISION_BUDGET_MS] elapsed since registration.
+     *
+     * Returns false if the coroutine was cancelled, in which case the caller must stop.
+     *
+     * The budget is measured from registration, not from this call, so on any screen
+     * opened more than a few seconds into the process this returns without waiting at all.
+     * The upper bound is a safety net for the case where the manager was never started.
+     */
+    protected suspend fun awaitBindDecision(): Boolean {
+        val deadline = System.currentTimeMillis() + XposedServiceManager.FULL_DECISION_BUDGET_MS
+        while (!XposedServiceManager.isDecided() && System.currentTimeMillis() < deadline) {
+            if (!coroutineContext.isActive) return false
+            delay(100L)
+        }
+        return coroutineContext.isActive
+    }
+
+    private fun confirmSoftReboot() {
+        val act = activity as? AppCompatActivity ?: return
+        lifecycleScope.launch {
+            // Same rule as the module check on the main screen: a pending bind is not a
+            // negative, so wait for a decided state instead of reading it straight off.
+            // In practice the budget elapsed long before the user reached this menu, so
+            // this does not actually wait.
+            if (!awaitBindDecision()) return@launch
+            if (act.isFinishing || act.isDestroyed || !isAdded) return@launch
+
+            if (XposedServiceManager.shouldReportInactive()) {
+                showXposedDialog(act)
+                return@launch
+            }
+            AlertDialog.Builder(getValidContext())
+                .setTitle(R.string.soft_reboot)
+                .setMessage(R.string.soft_reboot_ask)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    val intent = Intent(GlobalActions.ACTION_PREFIX + "FastReboot")
+                    intent.setPackage("com.android.systemui")
+                    getValidContext().sendBroadcast(intent)
+                }
+                .setNegativeButton(android.R.string.cancel) { _, _ -> }
+                .show()
+        }
+    }
+
+    /**
+     * Reports that the LSPosed service is not reachable.
+     *
+     * The wording deliberately stops short of "the module is not active". The state that
+     * gets here is usually [XposedServiceManager.State.TIMED_OUT], which is a bind that
+     * has not arrived yet, not a bind that failed - an unusually slow one still binds
+     * afterwards, and a dialog asserting the module is inactive would then be simply wrong.
+     */
     open fun showXposedDialog(act: AppCompatActivity?) {
         if (act == null || act.isFinishing || act.isDestroyed) return
         AlertDialog.Builder(act)
             .setTitle(R.string.warning)
-            .setMessage(R.string.module_not_active)
+            .setMessage(R.string.lsposed_not_connected)
             .setCancelable(true)
             .setPositiveButton(android.R.string.ok) { _, _ -> }
             .show()

--- a/app/src/main/java/tv/withaibuild/customiuizer/utils/XposedServiceManager.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/utils/XposedServiceManager.kt
@@ -3,6 +3,7 @@ package tv.withaibuild.customiuizer.utils
 import android.content.SharedPreferences
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import io.github.libxposed.service.RemotePreferences
 import io.github.libxposed.service.XposedService
 import io.github.libxposed.service.XposedServiceHelper
@@ -44,20 +45,53 @@ object XposedServiceManager {
     }
 
     /**
-     * Whether the module may be reported as inactive to the user.
+     * Whether the module may be reported as not connected to the user.
      *
-     * Only [State.DISCONNECTED] is a proven negative. [State.TIMED_OUT] qualifies solely
-     * because a caller that has already waited out its whole budget has to say something:
-     * pass `bindStillPending = true` only after such a wait, never straight off a state read.
+     * Only [State.DISCONNECTED] is a proven negative. [State.TIMED_OUT] qualifies only once
+     * [FULL_DECISION_BUDGET_MS] has elapsed since [init], because at that point a caller
+     * that keeps silent would never report a module that really is inactive.
+     *
+     * That elapsed check is deliberately owned here rather than passed in by callers. It
+     * used to be a `bindStillPending` flag, and the very first caller added after the
+     * flag - the soft-reboot menu item - passed `true` without waiting for anything,
+     * reintroducing the misjudgement the flag existed to prevent.
      */
     @JvmStatic
     @JvmOverloads
-    fun shouldReportInactive(current: State = state, bindStillPending: Boolean = false): Boolean =
+    fun shouldReportInactive(current: State = state): Boolean =
         when (current) {
             State.DISCONNECTED -> true
-            State.TIMED_OUT -> bindStillPending
+            State.TIMED_OUT -> decisionBudgetElapsed()
+            // UNKNOWN means the timeout has not even fired yet, so nothing has been
+            // observed and there is nothing to report.
             State.UNKNOWN, State.BOUND -> false
         }
+
+    /**
+     * Whether the bind state can still change the answer [shouldReportInactive] gives.
+     *
+     * A caller that is about to act on the state should wait for this, not for the state
+     * to stop being [State.isProvisional] - a bind that never arrives leaves the state
+     * provisional forever, and this is what puts a bound on the wait.
+     */
+    @JvmStatic
+    fun isDecided(): Boolean = !state.isProvisional || decisionBudgetElapsed()
+
+    /**
+     * Whether enough time has passed since [init] that a still-pending bind counts against
+     * the module.
+     *
+     * Measured from the registration attempt with [SystemClock.elapsedRealtime], so it is
+     * unaffected by the wall clock and by how long any particular screen has been open.
+     * Before [init] runs there is nothing to time, and nothing has been observed either,
+     * so the budget has not elapsed.
+     */
+    @JvmStatic
+    fun decisionBudgetElapsed(): Boolean {
+        val started = initElapsedRealtime
+        if (started == NOT_STARTED) return false
+        return SystemClock.elapsedRealtime() - started >= FULL_DECISION_BUDGET_MS
+    }
 
     @JvmField
     @Volatile
@@ -69,7 +103,14 @@ object XposedServiceManager {
     @JvmField
     var remotePrefs: RemotePreferences? = null
 
+    private const val NOT_STARTED = 0L
+
     private var initialized = false
+
+    /** [SystemClock.elapsedRealtime] at [init], or [NOT_STARTED]. */
+    @Volatile
+    private var initElapsedRealtime = NOT_STARTED
+
     private val handler = Handler(Looper.getMainLooper())
 
     /**
@@ -83,6 +124,17 @@ object XposedServiceManager {
      * slowest.
      */
     const val BIND_DECISION_TIMEOUT_MS = 3500L
+
+    /**
+     * Total time from [init] before a still-pending bind is allowed to count against the
+     * module. Two bind windows plus a margin: the first covers an ordinary start, the
+     * second covers a bind still in flight after a process restart - which is what a
+     * language change forces, and when binding is slowest.
+     *
+     * This lives here, not in a screen, so that every caller answers the question the same
+     * way regardless of when it happened to open.
+     */
+    const val FULL_DECISION_BUDGET_MS = BIND_DECISION_TIMEOUT_MS * 2 + 500L
 
     private val timeoutRunnable = Runnable {
         if (state == State.UNKNOWN) {
@@ -135,6 +187,7 @@ object XposedServiceManager {
     fun init(appPrefs: SharedPreferences?) {
         if (initialized) return
         initialized = true
+        initElapsedRealtime = SystemClock.elapsedRealtime()
 
         handler.removeCallbacks(timeoutRunnable)
         handler.postDelayed(timeoutRunnable, BIND_DECISION_TIMEOUT_MS)

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -833,7 +833,7 @@
     <string name="credentials_ok">Pověření jsou již odemčená</string>
     <string name="credentials_unlock">Odemknout pověření</string>
     <string name="credentials_success">Pověření odemčena!</string>
-    <string name="module_not_active">Modul není aktivní!\nOtevřete LSPosed aplikaci, aktivujte modul a restartujte.</string>
+    <string name="lsposed_not_connected">Zatím není připojeno ke službě LSPosed.\nPokud modul není aktivní, otevřete LSPosed, aktivujte jej a restartujte.</string>
     <string name="delete_item_info">Dlouhým stisknutím položky odstraníte</string>
     <string name="permission_scan">Chcete získat seznam sítí/zařízení, nebo ne\?</string>
     <string name="permission_permanent">Tuto možnost nyní musíte povolit ručně. Dobrá práce!</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -838,7 +838,7 @@
     <string name="credentials_ok">認証情報は既に解除されています。</string>
     <string name="credentials_unlock">認証情報の解除</string>
     <string name="credentials_success">認証情報を解除しました!</string>
-    <string name="module_not_active">モジュールは有効化されていません!\nLSPosedアプリを開き、モジュールを有効化後に再起動をしてください。</string>
+    <string name="lsposed_not_connected">LSPosed サービスにまだ接続できていません。\nモジュールが有効化されていない場合は、LSPosed アプリを開き、有効化してから再起動してください。</string>
     <string name="delete_item_info">削除する項目を長押しします</string>
     <string name="permission_scan">ネットワークまたはデバイスのリストを取得しますか?</string>
     <string name="permission_permanent">このオプションは手動で許可する必要があります。グッジョブ!!</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -838,7 +838,7 @@
     <string name="credentials_ok">As credenciais já estão desbloqueadas</string>
     <string name="credentials_unlock">Desbloquear credenciais</string>
     <string name="credentials_success">Credenciais desbloqueadas!</string>
-    <string name="module_not_active">O módulo não está ativo!\nAbra o LSPosed, ative o módulo e reinicie.</string>
+    <string name="lsposed_not_connected">Ainda não conectado ao serviço LSPosed.\nSe o módulo não estiver ativo, abra o LSPosed, ative-o e reinicie.</string>
     <string name="delete_item_info">Pressione e segure o item para excluir</string>
     <string name="permission_scan">Deseja obter uma lista de redes/dispositivos ou não?</string>
     <string name="permission_permanent">Agora você precisará habilitar manualmente a permissão para esta opção. Bom trabalho!</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -818,7 +818,7 @@
     <string name="credentials_ok">Учётные данные уже разблокированы</string>
     <string name="credentials_unlock">Разблокировать учётные данные</string>
     <string name="credentials_success">Учётные данные разблокированы!</string>
-    <string name="module_not_active">Модуль не активен!\nОткройте LSPosed, активируйте модуль и перезагрузите.</string>
+    <string name="lsposed_not_connected">Пока нет подключения к службе LSPosed.\nЕсли модуль не активирован, откройте LSPosed, активируйте его и перезагрузите.</string>
     <string name="delete_item_info">Используйте долгое нажатие для удаления</string>
     <string name="permission_scan">Вы хотите получить список сетей/устройств или нет?</string>
     <string name="permission_permanent">Теперь Вам придётся искать где вручную дать разрешение для данной функции. Так держать!</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -838,7 +838,7 @@
     <string name="credentials_ok">Chứng chỉ đã được mở khóa</string>
     <string name="credentials_unlock">Mở khóa chứng chỉ</string>
     <string name="credentials_success">Chứng chỉ đã được mở khóa!</string>
-    <string name="module_not_active">Mô-đun không hoạt động!\nMở ứng dụng LSPosed, kích hoạt mô-đun và khởi động lại.</string>
+    <string name="lsposed_not_connected">Chưa kết nối được tới dịch vụ LSPosed.\nNếu mô-đun chưa được kích hoạt, hãy mở LSPosed, kích hoạt và khởi động lại.</string>
     <string name="delete_item_info">Nhấn và giữ để xóa</string>
     <string name="permission_scan">Bạn có muốn nhận danh sách mạng/thiết bị không?</string>
     <string name="permission_permanent">Bây giờ bạn phải bật quyền cho tùy chọn này theo cách thủ công. Tốt lắm!</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -810,7 +810,7 @@
     <string name="credentials_ok">证书已解锁</string>
     <string name="credentials_unlock">解锁证书</string>
     <string name="credentials_success">证书已解锁！</string>
-    <string name="module_not_active">模块未被激活！\n请打开LSPosed应用，激活模块并重启。</string>
+    <string name="lsposed_not_connected">暂未连接到 LSPosed 服务。\n若模块尚未激活，请打开 LSPosed 应用，激活模块并重启。</string>
     <string name="delete_item_info">长按要删除的项目</string>
     <string name="permission_scan">您是否要获取网络/设备列表?</string>
     <string name="permission_permanent">现在您必须手动启用此选项的权限。很好！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -874,7 +874,7 @@
     <string name="credentials_unlock">Unlock credentials</string>
     <string name="credentials_success">Credentials unlocked!</string>
 
-    <string name="module_not_active">Module is not active!\nOpen LSPosed app, activate module and reboot.</string>
+    <string name="lsposed_not_connected">Not connected to the LSPosed service yet.\nIf the module is not activated, open LSPosed, activate it and reboot.</string>
     <string name="delete_item_info">Long press item to delete</string>
     <string name="permission_scan">Do you want to get a list of networks/devices or not?</string>
     <string name="permission_permanent">You\'ll have to manually enable permission for this option now. Good job!</string>

--- a/app/src/test/java/tv/withaibuild/customiuizer/utils/XposedBindStateTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/utils/XposedBindStateTest.kt
@@ -33,7 +33,11 @@ class XposedBindStateTest {
     }
 
     @Test
-    fun onlyDisconnectedReportsInactiveWithoutWaiting() {
+    fun disconnectedIsTheOnlyProvenNegative() {
+        // init() is never called in a unit test, so the budget has not elapsed: this is
+        // the "nothing has been observed yet" situation every caller starts in.
+        assertFalse(XposedServiceManager.decisionBudgetElapsed())
+
         assertTrue(XposedServiceManager.shouldReportInactive(State.DISCONNECTED))
         assertFalse(XposedServiceManager.shouldReportInactive(State.TIMED_OUT))
         assertFalse(XposedServiceManager.shouldReportInactive(State.UNKNOWN))
@@ -41,20 +45,48 @@ class XposedBindStateTest {
     }
 
     @Test
-    fun timedOutReportsInactiveOnlyAfterTheWholeBudgetIsSpent() {
-        assertFalse(XposedServiceManager.shouldReportInactive(State.TIMED_OUT, bindStillPending = false))
-        assertTrue(XposedServiceManager.shouldReportInactive(State.TIMED_OUT, bindStillPending = true))
+    fun timedOutIsNotReportableUntilTheBudgetElapses() {
+        // The regression guard for the soft-reboot menu item, which used to assert the
+        // budget was spent from a plain state read and so reported on TIMED_OUT at once.
+        assertFalse(XposedServiceManager.shouldReportInactive(State.TIMED_OUT))
     }
 
     @Test
-    fun aSpentBudgetNeverTurnsBoundIntoAnInactiveReport() {
-        assertFalse(XposedServiceManager.shouldReportInactive(State.BOUND, bindStillPending = true))
+    fun theBudgetSpansTwoBindWindows() {
+        // A single window is what expires into TIMED_OUT; the budget has to outlast it,
+        // or nothing would ever be waited out beyond the timeout that caused the bug.
+        assertTrue(
+            XposedServiceManager.FULL_DECISION_BUDGET_MS >
+                XposedServiceManager.BIND_DECISION_TIMEOUT_MS * 2
+        )
     }
 
     @Test
-    fun unknownIsNeverReportedInactive() {
-        // UNKNOWN can only survive a completed wait if the state machine was never
-        // started; that is not evidence of an inactive module either.
-        assertFalse(XposedServiceManager.shouldReportInactive(State.UNKNOWN, bindStillPending = true))
+    fun anUnstartedManagerNeverConcludesAnything() {
+        // Without init() there is no registration to time out, so a budget measured from
+        // it must not silently expire and turn UNKNOWN into a report.
+        assertFalse(XposedServiceManager.decisionBudgetElapsed())
+        assertFalse(XposedServiceManager.shouldReportInactive(State.UNKNOWN))
+    }
+
+    @Test
+    fun aDecidedStateIsDecidedRegardlessOfTheBudget() {
+        val original = XposedServiceManager.state
+        try {
+            XposedServiceManager.state = State.BOUND
+            assertTrue(XposedServiceManager.isDecided())
+
+            XposedServiceManager.state = State.DISCONNECTED
+            assertTrue(XposedServiceManager.isDecided())
+
+            // Provisional with an unstarted budget: callers must keep waiting.
+            XposedServiceManager.state = State.TIMED_OUT
+            assertFalse(XposedServiceManager.isDecided())
+
+            XposedServiceManager.state = State.UNKNOWN
+            assertFalse(XposedServiceManager.isDecided())
+        } finally {
+            XposedServiceManager.state = original
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #13, which left two gaps.

## 1. Soft reboot never actually waited

`#13` added `shouldReportInactive(state, bindStillPending)` and documented it as *"pass `bindStillPending = true` only after such a wait, never straight off a state read."* The soft-reboot menu item then did precisely that:

```kotlin
if (XposedServiceManager.shouldReportInactive(bindStillPending = true)) {
```

In `TIMED_OUT` that reports immediately — the same misjudgement the parameter existed to prevent, on a code path that never waited for anything. `#13` fixed the `UNKNOWN` half of this call site and left the `TIMED_OUT` half exactly as broken as before.

A flag every caller has to set correctly is the wrong shape for this, so the question moves inside `XposedServiceManager`:

- `init()` records `SystemClock.elapsedRealtime()`, and `decisionBudgetElapsed()` answers from it. Monotonic, so it is unaffected by the wall clock or by how long a screen has been open.
- `shouldReportInactive()` takes no flag. `TIMED_OUT` becomes reportable only once the budget has elapsed. There is nothing left for a caller to get wrong.
- `FULL_DECISION_BUDGET_MS` moves out of `MainFragment` into the manager, so every caller answers the question the same way regardless of when it opened.

## 2. Waiting on `isProvisional` alone has no bound

`isDecided()` is the thing to wait on, not `!state.isProvisional`. A bind that never arrives leaves the state provisional forever; the elapsed budget is what terminates the wait.

Both screens now share `awaitBindDecision()` on `PreferenceFragmentBase`. Because the budget runs from registration rather than from the call, a screen opened more than a few seconds into the process returns from it without waiting at all — so soft reboot pays nothing in practice, while still being correct if tapped during a slow bind. It does this off the main thread and only then shows either dialog.

## 3. The dialog claimed more than the state supports

The state that reaches `showXposedDialog` is usually `TIMED_OUT` — a bind that has not arrived yet, not one that failed. An unusually slow bind still succeeds afterwards, which leaves "Module is not active!" simply false.

The message now reads as not yet connected to the LSPosed service, and keeps the activation guidance conditional:

> Not connected to the LSPosed service yet.
> If the module is not activated, open LSPosed, activate it and reboot.

The key is renamed `module_not_active` → `lsposed_not_connected` so no translation silently keeps the absolute wording. All seven locales that carried the old string are updated (en, zh-CN, cs, ja, pt-BR, ru, vi); es-ES, tr-TR and zh-TW never had it and continue to fall back to the base string.

## Tests

`XposedBindStateTest` is reworked for the new shape. The regression guard is `timedOutIsNotReportableUntilTheBudgetElapses` — the exact case the soft-reboot call site got wrong. Also pinned: an unstarted manager never concludes anything (a budget measured from `init` must not silently expire when `init` never ran), and `isDecided` is true for decided states regardless of the budget.

## Verification status

**Still not built or tested here** — the sandbox blocks the Maven repositories, so Gradle cannot resolve AGP and fails at configuration. This repo has no GitHub Actions workflows, so nothing on the PR will compile it either.

Reviewed by hand; `strings.xml` well-formedness was checked programmatically across all 10 locale files, and no stale `module_not_active` or `bindStillPending` references remain. Please run `./gradlew :app:testDebugUnitTest` locally before merging — #13 went in without ever being compiled, and this builds on it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtrnLGif9KEqzG8KyrsRq6)_