### PR TITLE
release: r14.20.6 / 203

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.
 - `MethodHook` body PrefMap reads are now frozen at zero and guarded by a scanner ceiling check.
 - Preference changes refresh immutable snapshots without reinstalling hooks.
 
+### Fixes
+
+- Gesture and other MultiAction edit pages persist the selected action, app, shortcut, activity, and toggle on confirm. SpinnerEx controls were previously skipped because they are ViewGroups.
+
 ### Audit Evidence
 
 - `python tools/verify.py full` passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.
 - `python -m unittest discover -s tools/tests -p "test_*.py"` passed.
 - Feature-semantics validation and invariant checks passed.
 
+### Artifact Information
+
+- APK: `CustoMIUIzer-A14-r14.20.6.apk`
+- versionCode / versionName: `203 / r14.20.6`
+
+---
+
 ## r14.20.5 — 2026-08-18
 
 Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.
 ### Fixes
 
 - Gesture and other MultiAction edit pages persist the selected action, app, shortcut, activity, and toggle on confirm. SpinnerEx controls were previously skipped because they are ViewGroups.
+- Launcher gesture matched restart now also restarts SystemUI, so action execution receivers are installed with the detector hooks.
 
 ### Audit Evidence
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,22 +6,16 @@ English | [简体中文](CHANGELOG_CN.md)
 
 Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.
 
-### Performance and Hot Path Safety
-
-- Completed the hook-body PrefMap migration backlog, prioritized by hook-body count and process hotness.
-- `MethodHook` body PrefMap reads are now frozen at zero and guarded by a scanner ceiling check.
-- Preference changes refresh immutable snapshots without reinstalling hooks.
-
 ### Fixes
 
-- Gesture and other MultiAction edit pages persist the selected action, app, shortcut, activity, and toggle on confirm. SpinnerEx controls were previously skipped because they are ViewGroups.
-- Launcher gesture matched restart now also restarts SystemUI, so action execution receivers are installed with the detector hooks.
+- Launcher gestures and other MultiAction pages now keep the selected action after save and reopen.
+- Launcher → Gestures “restart related components” now restarts both the launcher and SystemUI.
 
-### Audit Evidence
+### Performance and Stability
 
-- `python tools/verify.py full` passed.
-- `python -m unittest discover -s tools/tests -p "test_*.py"` passed.
-- Feature-semantics validation and invariant checks passed.
+- Home-screen gesture hot path reuses preallocated command lists.
+- Some GlobalActions reflection methods are cached.
+- PrefMap reads in `MethodHook` bodies are frozen at zero and guarded by a scanner ceiling. Preference changes refresh snapshots without reinstalling hooks.
 
 ### Artifact Information
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -6,22 +6,16 @@
 
 面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。
 
-### 性能与热路径安全
-
-- 完成按 hook-body 数量与进程热度排序的 PrefMap 迁移积压。
-- `MethodHook` 体内 PrefMap 读取已冻结为零，并由扫描上限门禁保护。
-- 偏好变更刷新不可变快照，不再重装 Hook。
-
 ### 修复
 
-- 手势及其他 MultiAction 编辑页在确认后会真正写入所选动作、应用、快捷方式、Activity 与开关。此前 SpinnerEx 作为 ViewGroup 被保存遍历跳过。
-- 启动器手势页的匹配重启现在同时重启 SystemUI，动作执行接收端会与检测 Hook 一起生效。
+- 启动器手势以及导航栏、状态栏、锁屏、启动等 MultiAction 页面，选择动作后可以保存，重新进入仍保持设置。
+- 启动器 → 手势页的「重启相关组件」会同时重启桌面和系统界面。
 
-### 审计证据
+### 性能与稳定性
 
-- `python tools/verify.py full` 已通过。
-- `python -m unittest discover -s tools/tests -p "test_*.py"` 已通过。
-- 功能语义校验与不变量检查已通过。
+- 桌面手势热路径复用预分配命令列表。
+- 全局动作部分反射方法改为缓存。
+- Hook 体内 PrefMap 读取已清零并由扫描上限保护；偏好变化刷新快照，不再重装 Hook。
 
 ### 产物信息
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -2,6 +2,29 @@
 
 [English](CHANGELOG.md) | 简体中文
 
+## r14.20.6 — 2026-08-18
+
+面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。
+
+### 性能与热路径安全
+
+- 完成按 hook-body 数量与进程热度排序的 PrefMap 迁移积压。
+- `MethodHook` 体内 PrefMap 读取已冻结为零，并由扫描上限门禁保护。
+- 偏好变更刷新不可变快照，不再重装 Hook。
+
+### 审计证据
+
+- `python tools/verify.py full` 已通过。
+- `python -m unittest discover -s tools/tests -p "test_*.py"` 已通过。
+- 功能语义校验与不变量检查已通过。
+
+### 产物信息
+
+- APK：`CustoMIUIzer-A14-r14.20.6.apk`
+- versionCode / versionName：`203 / r14.20.6`
+
+---
+
 ## r14.20.5 — 2026-08-18
 
 面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -12,6 +12,10 @@
 - `MethodHook` 体内 PrefMap 读取已冻结为零，并由扫描上限门禁保护。
 - 偏好变更刷新不可变快照，不再重装 Hook。
 
+### 修复
+
+- 手势及其他 MultiAction 编辑页在确认后会真正写入所选动作、应用、快捷方式、Activity 与开关。此前 SpinnerEx 作为 ViewGroup 被保存遍历跳过。
+
 ### 审计证据
 
 - `python tools/verify.py full` 已通过。

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -15,6 +15,7 @@
 ### 修复
 
 - 手势及其他 MultiAction 编辑页在确认后会真正写入所选动作、应用、快捷方式、Activity 与开关。此前 SpinnerEx 作为 ViewGroup 被保存遍历跳过。
+- 启动器手势页的匹配重启现在同时重启 SystemUI，动作执行接收端会与检测 Hook 一起生效。
 
 ### 审计证据
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CustoMIUIzer A14 是面向 **HyperOS 1 / Android 14（SDK 34）** 的系统界面与交互定制模块，基于 CustoMIUIzer 项目持续维护。它使用独立包名和版本线，不是上游官方版本。
 
-- 当前正式版：`r14.20.5`
+- 当前正式版：`r14.20.6`
 - 应用 ID：`tv.withaibuild.customiuizer.r14`
 - 源码仓库：<https://github.com/tomthenpc/customiuizer-a14>
 - 用户下载：<https://github.com/Xposed-Modules-Repo/tv.withaibuild.customiuizer.r14/releases>

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 
 CustoMIUIzer A14 is a system UI and interaction customization module maintained for **HyperOS 1 / Android 14 (SDK 34)**. It has an independent package and release line and is not an official upstream release.
 
-- Current release: `r14.20.5`
+- Current release: `r14.20.6`
 - Application ID: `tv.withaibuild.customiuizer.r14`
 - Source: <https://github.com/tomthenpc/customiuizer-a14>
 - User downloads: <https://github.com/Xposed-Modules-Repo/tv.withaibuild.customiuizer.r14/releases>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ if (officialRelease) {
     }
 }
 
-val lastVersion = 202
-val lastVersionName = "r14.20.5"
+val lastVersion = 203
+val lastVersionName = "r14.20.6"
 
 fun resolveBuildRevision(): String {
     val prop = project.findProperty("buildRevision")?.toString()

--- a/app/src/main/java/tv/withaibuild/customiuizer/EditPreferencePersistence.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/EditPreferencePersistence.kt
@@ -1,0 +1,105 @@
+package tv.withaibuild.customiuizer
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import tv.withaibuild.customiuizer.prefs.SpinnerEx
+import tv.withaibuild.customiuizer.prefs.SpinnerExFake
+
+/**
+ * Persistence kinds for Edit-page view trees.
+ *
+ * [SpinnerEx] / [SpinnerExFake] extend AdapterView and are therefore ViewGroups.
+ * A generic "skip containers" walk never visits them; a generic
+ * "include containers" walk can visit the same parent once per child.
+ * Spinner kinds are treated as leaves so each control is saved exactly once
+ * and AdapterView chrome (the selected-item TextView) is not persisted.
+ */
+internal enum class EditPersistenceKind {
+    SPINNER_INT,
+    SPINNER_FAKE,
+    TEXT,
+    GROUP,
+    OTHER,
+}
+
+internal fun editPersistenceKind(view: View): EditPersistenceKind = when (view) {
+    is SpinnerExFake -> EditPersistenceKind.SPINNER_FAKE
+    is SpinnerEx -> EditPersistenceKind.SPINNER_INT
+    is TextView -> EditPersistenceKind.TEXT
+    is ViewGroup -> EditPersistenceKind.GROUP
+    else -> EditPersistenceKind.OTHER
+}
+
+internal fun isEditPersistenceLeaf(kind: EditPersistenceKind): Boolean =
+    kind == EditPersistenceKind.SPINNER_INT ||
+        kind == EditPersistenceKind.SPINNER_FAKE ||
+        kind == EditPersistenceKind.TEXT
+
+internal fun <T> collectEditPersistenceViews(
+    root: T?,
+    kindOf: (T) -> EditPersistenceKind,
+    childrenOf: (T) -> List<T>,
+): List<T> {
+    val out = ArrayList<T>()
+    fun walk(node: T?) {
+        node ?: return
+        val kind = kindOf(node)
+        if (isEditPersistenceLeaf(kind)) {
+            out.add(node)
+            return
+        }
+        if (kind == EditPersistenceKind.GROUP) {
+            for (child in childrenOf(node)) {
+                walk(child)
+            }
+        }
+    }
+    walk(root)
+    return out
+}
+
+internal fun collectEditPersistenceViews(root: View?): List<View> {
+    return collectEditPersistenceViews(
+        root,
+        kindOf = ::editPersistenceKind,
+        childrenOf = { view ->
+            val group = view as? ViewGroup
+            if (group == null) {
+                emptyList()
+            } else {
+                val count = group.childCount
+                if (count <= 0) {
+                    emptyList()
+                } else {
+                    (0 until count).map { group.getChildAt(it) }
+                }
+            }
+        },
+    )
+}
+
+internal fun applyTaggedEditPersistence(
+    kind: EditPersistenceKind,
+    tag: String?,
+    onSpinnerInt: () -> Unit,
+    onSpinnerFake: () -> Unit,
+    onText: () -> Unit,
+): Boolean {
+    if (tag.isNullOrEmpty()) return false
+    return when (kind) {
+        EditPersistenceKind.SPINNER_FAKE -> {
+            onSpinnerFake()
+            true
+        }
+        EditPersistenceKind.SPINNER_INT -> {
+            onSpinnerInt()
+            true
+        }
+        EditPersistenceKind.TEXT -> {
+            onText()
+            true
+        }
+        else -> false
+    }
+}

--- a/app/src/main/java/tv/withaibuild/customiuizer/SubFragment.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/SubFragment.kt
@@ -247,28 +247,27 @@ open class SubFragment : PreferenceFragmentBase() {
             Log.e("miuizer", "View not yet ready!")
             return
         }
-        val nViews = Helpers.getChildViewsRecursive(root.findViewById(R.id.container), false)
+        val nViews = collectEditPersistenceViews(root.findViewById(R.id.container))
         val editor = AppHelper.appPrefs?.edit() ?: return
         var dirty = false
         for (nView in nViews) {
             try {
-                if (nView.tag != null) {
-                    when (nView) {
-                        is TextView -> {
-                            editor.putString(nView.tag as String, nView.text.toString())
-                            dirty = true
-                        }
-                        is SpinnerExFake -> {
-                            editor.putString(nView.tag as String, nView.value)
-                            dirty = true
-                            nView.applyOthers()
-                        }
-                        is SpinnerEx -> {
-                            editor.putInt(nView.tag as String, nView.getSelectedArrayValue())
-                            dirty = true
-                        }
-                    }
-                }
+                val wrote = applyTaggedEditPersistence(
+                    editPersistenceKind(nView),
+                    nView.tag as? String,
+                    onSpinnerInt = {
+                        editor.putInt(nView.tag as String, (nView as SpinnerEx).getSelectedArrayValue())
+                    },
+                    onSpinnerFake = {
+                        val spinner = nView as SpinnerExFake
+                        editor.putString(nView.tag as String, spinner.value)
+                        spinner.applyOthers()
+                    },
+                    onText = {
+                        editor.putString(nView.tag as String, (nView as TextView).text.toString())
+                    },
+                )
+                if (wrote) dirty = true
             } catch (e: Throwable) {
                 Log.e("miuizer", "Cannot save sub preference!")
             }
@@ -281,11 +280,11 @@ open class SubFragment : PreferenceFragmentBase() {
             Log.e("miuizer", "View not yet ready!")
             return
         }
-        val nViews = Helpers.getChildViewsRecursive(root.findViewById(R.id.container), false)
+        val nViews = collectEditPersistenceViews(root.findViewById(R.id.container))
         for (nView in nViews) {
             try {
-                if (nView.tag != null && nView is TextView) {
-                    nView.text = AppHelper.getStringOfAppPrefs(nView.tag as String, "")
+                if (nView.tag != null && editPersistenceKind(nView) == EditPersistenceKind.TEXT) {
+                    (nView as TextView).text = AppHelper.getStringOfAppPrefs(nView.tag as String, "")
                 }
             } catch (e: Throwable) {
                 Log.e("miuizer", "Cannot load sub preference!")

--- a/app/src/main/java/tv/withaibuild/customiuizer/utils/RestartPagePolicy.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/utils/RestartPagePolicy.kt
@@ -26,7 +26,7 @@ internal object RestartPagePolicy {
         R.xml.prefs_launcher_bugfixes -> RestartMask.LAUNCHER
         R.xml.prefs_launcher_cat -> RestartMask.NONE
         R.xml.prefs_launcher_folders -> RestartMask.LAUNCHER
-        R.xml.prefs_launcher_gestures -> RestartMask.LAUNCHER
+        R.xml.prefs_launcher_gestures -> RestartMask.LAUNCHER or RestartMask.SYSTEMUI
         R.xml.prefs_launcher_other -> RestartMask.LAUNCHER
         R.xml.prefs_launcher_privacyapps -> RestartMask.LAUNCHER or RestartMask.SECURITY_CENTER
         R.xml.prefs_launcher_titles -> RestartMask.LAUNCHER
@@ -98,7 +98,7 @@ internal object RestartPagePolicy {
         R.xml.prefs_launcher -> when (sub) {
             "pref_key_launcher_cat_bugfixes" -> RestartMask.LAUNCHER
             "pref_key_launcher_cat_folders" -> RestartMask.LAUNCHER
-            "pref_key_launcher_cat_gestures" -> RestartMask.LAUNCHER
+            "pref_key_launcher_cat_gestures" -> RestartMask.LAUNCHER or RestartMask.SYSTEMUI
             "pref_key_launcher_cat_other" -> RestartMask.LAUNCHER
             "pref_key_launcher_cat_privacyapps" -> RestartMask.LAUNCHER or RestartMask.SECURITY_CENTER
             "pref_key_launcher_cat_titles" -> RestartMask.LAUNCHER

--- a/app/src/test/java/tv/withaibuild/customiuizer/EditPreferencePersistenceTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/EditPreferencePersistenceTest.kt
@@ -1,0 +1,220 @@
+package tv.withaibuild.customiuizer
+
+import android.view.ViewGroup
+import android.widget.TextView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tv.withaibuild.customiuizer.prefs.SpinnerEx
+import tv.withaibuild.customiuizer.prefs.SpinnerExFake
+
+class EditPreferencePersistenceTest {
+
+    private class FakeNode(
+        val name: String,
+        val kind: EditPersistenceKind,
+        val tag: String? = null,
+        val spinnerInt: Int = 0,
+        val fakeValue: String? = null,
+        val fakeExtras: List<Pair<String, String>> = emptyList(),
+        val text: String = "",
+        val children: MutableList<FakeNode> = mutableListOf(),
+    ) {
+        fun add(child: FakeNode): FakeNode {
+            children.add(child)
+            return this
+        }
+    }
+
+    @Test
+    fun spinnerEx_is_a_view_group_so_generic_skip_containers_cannot_see_it() {
+        assertTrue(ViewGroup::class.java.isAssignableFrom(SpinnerEx::class.java))
+        assertTrue(SpinnerEx::class.java.isAssignableFrom(SpinnerExFake::class.java))
+        assertFalse(TextView::class.java.isAssignableFrom(SpinnerEx::class.java))
+    }
+
+    @Test
+    fun collector_includes_spinner_leaves_once_and_skips_adapter_chrome() {
+        val tree = multiActionTree()
+        val collected = collect(tree)
+        val names = collected.map { it.name }
+
+        assertEquals(
+            listOf("title", "action", "app_label", "app", "shortcut_label", "shortcut", "activity_label", "activity", "activity_class", "toggle_label", "toggle"),
+            names,
+        )
+        assertEquals(1, collected.count { it.name == "action" })
+        assertEquals(1, collected.count { it.name == "app" })
+        assertEquals(1, collected.count { it.name == "toggle" })
+        assertFalse(names.contains("action_chrome"))
+        assertFalse(names.contains("app_chrome"))
+        assertFalse(names.contains("fields"))
+        assertFalse(names.contains("apps_group"))
+        assertFalse(names.contains("container"))
+    }
+
+    @Test
+    fun legacy_skip_view_groups_misses_spinner_ex_and_only_sees_chrome_text() {
+        val tree = multiActionTree()
+        val legacy = legacyCollectSkippingViewGroups(tree)
+        val names = legacy.map { it.name }
+
+        assertFalse(names.contains("action"))
+        assertFalse(names.contains("app"))
+        assertFalse(names.contains("shortcut"))
+        assertFalse(names.contains("activity"))
+        assertFalse(names.contains("toggle"))
+        assertTrue(names.contains("action_chrome"))
+        assertTrue(names.contains("app_chrome"))
+    }
+
+    @Test
+    fun include_containers_true_would_repeat_parents_new_collector_does_not() {
+        val parent = FakeNode("parent", EditPersistenceKind.GROUP)
+        parent.add(FakeNode("a", EditPersistenceKind.TEXT, tag = "a"))
+        parent.add(FakeNode("b", EditPersistenceKind.TEXT, tag = "b"))
+
+        val duplicatedParents = ArrayList<String>()
+        for (child in parent.children) {
+            duplicatedParents.add(parent.name)
+            duplicatedParents.add(child.name)
+        }
+        assertEquals(listOf("parent", "a", "parent", "b"), duplicatedParents)
+
+        val collected = collect(parent)
+        assertEquals(listOf("a", "b"), collected.map { it.name })
+        assertEquals(0, collected.count { it.name == "parent" })
+    }
+
+    @Test
+    fun selected_action_is_written_and_reloads_to_the_same_value() {
+        val key = "pref_key_launcher_swipedown"
+        val launcherValues = intArrayOf(1, 2, 3, 4, 5, 6, 7, 17, 12, 26, 8, 9, 20, 10, 13, 14, 22, 23)
+        val selectedAction = 4
+        val tree = multiActionTree(actionValue = selectedAction, appValue = "com.example/.Main")
+
+        val ints = LinkedHashMap<String, Int>()
+        val strings = LinkedHashMap<String, String?>()
+        var fakeApplyCount = 0
+
+        for (node in collect(tree)) {
+            applyTaggedEditPersistence(
+                node.kind,
+                node.tag,
+                onSpinnerInt = { ints[node.tag!!] = node.spinnerInt },
+                onSpinnerFake = {
+                    strings[node.tag!!] = node.fakeValue
+                    for (extra in node.fakeExtras) {
+                        strings[extra.first] = extra.second
+                    }
+                    fakeApplyCount += 1
+                },
+                onText = { strings[node.tag!!] = node.text },
+            )
+        }
+
+        assertEquals(selectedAction, ints["${key}_action"])
+        assertEquals(2, ints["${key}_toggle"])
+        assertEquals("com.example/.Main", strings["${key}_app"])
+        assertEquals("pkg/shortcut", strings["${key}_shortcut"])
+        assertEquals("intent://shortcut", strings["${key}_shortcut_intent"])
+        assertEquals("pkg/.Activity", strings["${key}_activity"])
+        assertEquals(3, fakeApplyCount)
+
+        val reloadedIndex = SpinnerEx.resolveSelectionIndex(ints["${key}_action"]!!, launcherValues)
+        assertEquals(3, reloadedIndex)
+        assertEquals(selectedAction, SpinnerEx.resolveSelectedValue(reloadedIndex, launcherValues))
+
+        val missingKeyReloadsAsNone = SpinnerEx.resolveSelectionIndex(1, launcherValues)
+        assertEquals(0, missingKeyReloadsAsNone)
+        assertEquals(1, SpinnerEx.resolveSelectedValue(missingKeyReloadsAsNone, launcherValues))
+    }
+
+    @Test
+    fun untagged_text_and_groups_do_not_write_prefs() {
+        val title = FakeNode("title", EditPersistenceKind.TEXT, text = "Action")
+        val group = FakeNode("group", EditPersistenceKind.GROUP).add(title)
+        var wrote = false
+        for (node in collect(group)) {
+            wrote = applyTaggedEditPersistence(
+                node.kind,
+                node.tag,
+                onSpinnerInt = { wrote = true },
+                onSpinnerFake = { wrote = true },
+                onText = { wrote = true },
+            ) || wrote
+        }
+        assertFalse(wrote)
+    }
+
+    private fun collect(root: FakeNode): List<FakeNode> {
+        return collectEditPersistenceViews(
+            root,
+            kindOf = { it.kind },
+            childrenOf = { it.children },
+        )
+    }
+
+    private fun legacyCollectSkippingViewGroups(root: FakeNode): List<FakeNode> {
+        val out = ArrayList<FakeNode>()
+        fun walk(node: FakeNode) {
+            val isViewGroup = node.kind == EditPersistenceKind.GROUP ||
+                node.kind == EditPersistenceKind.SPINNER_INT ||
+                node.kind == EditPersistenceKind.SPINNER_FAKE
+            if (isViewGroup) {
+                for (child in node.children) walk(child)
+            } else {
+                out.add(node)
+            }
+        }
+        walk(root)
+        return out
+    }
+
+    private fun multiActionTree(
+        actionValue: Int = 4,
+        appValue: String? = "com.example/.Main",
+    ): FakeNode {
+        val key = "pref_key_launcher_swipedown"
+        val fields = FakeNode("fields", EditPersistenceKind.GROUP)
+            .add(FakeNode("title", EditPersistenceKind.TEXT, text = "Action"))
+            .add(
+                FakeNode("action", EditPersistenceKind.SPINNER_INT, tag = "${key}_action", spinnerInt = actionValue)
+                    .add(FakeNode("action_chrome", EditPersistenceKind.TEXT, text = "Lock")),
+            )
+            .add(
+                FakeNode("apps_group", EditPersistenceKind.GROUP)
+                    .add(FakeNode("app_label", EditPersistenceKind.TEXT, text = "App"))
+                    .add(
+                        FakeNode("app", EditPersistenceKind.SPINNER_FAKE, tag = "${key}_app", fakeValue = appValue)
+                            .add(FakeNode("app_chrome", EditPersistenceKind.TEXT, text = "Example")),
+                    ),
+            )
+            .add(
+                FakeNode("shortcuts_group", EditPersistenceKind.GROUP)
+                    .add(FakeNode("shortcut_label", EditPersistenceKind.TEXT, text = "Shortcut"))
+                    .add(
+                        FakeNode(
+                            "shortcut",
+                            EditPersistenceKind.SPINNER_FAKE,
+                            tag = "${key}_shortcut",
+                            fakeValue = "pkg/shortcut",
+                            fakeExtras = listOf("${key}_shortcut_intent" to "intent://shortcut"),
+                        ),
+                    ),
+            )
+            .add(
+                FakeNode("activities_group", EditPersistenceKind.GROUP)
+                    .add(FakeNode("activity_label", EditPersistenceKind.TEXT, text = "Activity"))
+                    .add(FakeNode("activity", EditPersistenceKind.SPINNER_FAKE, tag = "${key}_activity", fakeValue = "pkg/.Activity"))
+                    .add(FakeNode("activity_class", EditPersistenceKind.TEXT, text = "pkg/.Activity")),
+            )
+            .add(
+                FakeNode("toggles_group", EditPersistenceKind.GROUP)
+                    .add(FakeNode("toggle_label", EditPersistenceKind.TEXT, text = "Toggle"))
+                    .add(FakeNode("toggle", EditPersistenceKind.SPINNER_INT, tag = "${key}_toggle", spinnerInt = 2)),
+            )
+        return FakeNode("container", EditPersistenceKind.GROUP).add(fields)
+    }
+}

--- a/app/src/test/java/tv/withaibuild/customiuizer/utils/RestartPagePolicyTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/utils/RestartPagePolicyTest.kt
@@ -17,6 +17,38 @@ class RestartPagePolicyTest {
     }
 
     @Test
+    fun launcher_gestures_page_restarts_launcher_and_systemui() {
+        val expected = RestartMask.LAUNCHER or RestartMask.SYSTEMUI
+        assertEquals(expected, RestartPagePolicy.maskFor(R.xml.prefs_launcher_gestures))
+        assertEquals(
+            expected,
+            RestartPagePolicy.maskFor(R.xml.prefs_launcher, "pref_key_launcher_cat_gestures")
+        )
+        assertEquals(listOf("launcher", "systemui"), RestartPagePolicy.toNameList(expected))
+        assertEquals(0, expected and RestartMask.SECURITY_CENTER)
+        assertEquals(
+            expected,
+            expected and (RestartMask.LAUNCHER or RestartMask.SYSTEMUI or RestartMask.SECURITY_CENTER)
+        )
+    }
+
+    @Test
+    fun other_launcher_category_pages_keep_previous_masks() {
+        assertEquals(RestartMask.LAUNCHER, RestartPagePolicy.maskFor(R.xml.prefs_launcher_folders))
+        assertEquals(RestartMask.LAUNCHER, RestartPagePolicy.maskFor(R.xml.prefs_launcher_titles))
+        assertEquals(RestartMask.LAUNCHER, RestartPagePolicy.maskFor(R.xml.prefs_launcher_bugfixes))
+        assertEquals(RestartMask.LAUNCHER, RestartPagePolicy.maskFor(R.xml.prefs_launcher_other))
+        assertEquals(
+            RestartMask.LAUNCHER or RestartMask.SECURITY_CENTER,
+            RestartPagePolicy.maskFor(R.xml.prefs_launcher_privacyapps)
+        )
+        assertEquals(
+            RestartMask.LAUNCHER,
+            RestartPagePolicy.maskFor(R.xml.prefs_launcher, "pref_key_launcher_cat_folders")
+        )
+    }
+
+    @Test
     fun securityCenter_only_page() {
         assertEquals(RestartMask.SECURITY_CENTER, RestartPagePolicy.maskFor(R.xml.prefs_various_security_center))
     }
@@ -69,7 +101,7 @@ class RestartPagePolicyTest {
             RestartPagePolicy.maskFor(R.xml.prefs_controls, "pref_key_controls_cat_fsg")
         )
         assertEquals(
-            RestartMask.LAUNCHER,
+            RestartMask.LAUNCHER or RestartMask.SYSTEMUI,
             RestartPagePolicy.maskFor(R.xml.prefs_launcher, "pref_key_launcher_cat_gestures")
         )
         assertEquals(
@@ -131,7 +163,7 @@ class RestartPagePolicyTest {
             RestartPagePolicy.maskFor(R.xml.prefs_controls, "pref_key_controls_cat_fsg")
         )
         assertEquals(
-            RestartMask.LAUNCHER,
+            RestartMask.LAUNCHER or RestartMask.SYSTEMUI,
             RestartPagePolicy.maskFor(R.xml.prefs_launcher, "pref_key_launcher_cat_gestures")
         )
         assertEquals(


### PR DESCRIPTION
## Summary
- Align version to r14.20.6 / 203.
- Persist MultiAction SpinnerEx values on confirm.
- Restart SystemUI together with the launcher on the gestures page.
- User-facing changelog for r14.20.6.

## Test plan
- [x] Device: gesture action save/reload PASS
- [x] Device: matched restart Launcher + SystemUI PASS
- [ ] Fast CI after merge
- [ ] Full CI on r14.20.6 tag


Made with [Cursor](https://cursor.com)