### PR TITLE
r14.20.7 restore MultiAction and launcher gesture contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 English | [简体中文](CHANGELOG_CN.md)
 
+## r14.20.7 — 2026-08-19
+
+Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.
+
+### Fixes
+
+- Opening Launch App / Launch Shortcut / Launch Activity from an Extended Action page no longer crashes.
+- The MultiAction Toggle action works again.
+- Lock-screen Extended Action now shows Toggle aligned with its stored value.
+
+### Stability
+
+- Launcher's ten gesture actions now have mapping and execution contract checks.
+- MultiAction action, toggle, and array contracts now reject advertised IDs without handlers and label/value mismatches.
+
+### Artifact Information
+
+- APK: `CustoMIUIzer-A14-r14.20.7.apk`
+- versionCode / versionName: `204 / r14.20.7`
+
+---
+
 ## r14.20.6 — 2026-08-18
 
 Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -2,6 +2,28 @@
 
 [English](CHANGELOG.md) | 简体中文
 
+## r14.20.7 — 2026-08-19
+
+面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。
+
+### 修复
+
+- 修复扩展动作页面进入「启动应用 / 启动快捷方式 / 启动活动」选择页面时可能闪退的问题。
+- 修复 MultiAction「切换功能」动作失效的问题。
+- 修复锁屏扩展动作「切换功能」显示项与内部值不一致的问题。
+
+### 稳定性
+
+- 完善启动器 10 项手势动作的映射与执行契约校验。
+- 完善 MultiAction action / toggle / array contract，防止 UI 暴露无执行端动作或 label/value 再次错位。
+
+### 产物信息
+
+- APK：`CustoMIUIzer-A14-r14.20.7.apk`
+- versionCode / versionName：`204 / r14.20.7`
+
+---
+
 ## r14.20.6 — 2026-08-18
 
 面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CustoMIUIzer A14 是面向 **HyperOS 1 / Android 14（SDK 34）** 的系统界面与交互定制模块，基于 CustoMIUIzer 项目持续维护。它使用独立包名和版本线，不是上游官方版本。
 
-- 当前正式版：`r14.20.6`
+- 当前正式版：`r14.20.7`
 - 应用 ID：`tv.withaibuild.customiuizer.r14`
 - 源码仓库：<https://github.com/tomthenpc/customiuizer-a14>
 - 用户下载：<https://github.com/Xposed-Modules-Repo/tv.withaibuild.customiuizer.r14/releases>

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 
 CustoMIUIzer A14 is a system UI and interaction customization module maintained for **HyperOS 1 / Android 14 (SDK 34)**. It has an independent package and release line and is not an official upstream release.
 
-- Current release: `r14.20.6`
+- Current release: `r14.20.7`
 - Application ID: `tv.withaibuild.customiuizer.r14`
 - Source: <https://github.com/tomthenpc/customiuizer-a14>
 - User downloads: <https://github.com/Xposed-Modules-Repo/tv.withaibuild.customiuizer.r14/releases>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ if (officialRelease) {
     }
 }
 
-val lastVersion = 203
-val lastVersionName = "r14.20.6"
+val lastVersion = 204
+val lastVersionName = "r14.20.7"
 
 fun resolveBuildRevision(): String {
     val prop = project.findProperty("buildRevision")?.toString()

--- a/app/src/main/java/tv/withaibuild/customiuizer/NavigationFeedback.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/NavigationFeedback.kt
@@ -1,0 +1,25 @@
+package tv.withaibuild.customiuizer
+
+/**
+ * Navigation press-feedback cleanup is shared by Preference pages and Edit pages.
+ * Only PreferenceFragmentCompat initializes a RecyclerView list. Edit pages are a
+ * legal state with no list; that must skip list cleanup instead of crashing.
+ */
+object NavigationFeedback {
+
+    data class Plan(
+        val clearFragmentRoot: Boolean,
+        val cleanPreferenceList: Boolean,
+    )
+
+    @JvmStatic
+    fun plan(hasFragmentView: Boolean, hasPreferenceList: Boolean): Plan {
+        if (!hasFragmentView) {
+            return Plan(clearFragmentRoot = false, cleanPreferenceList = false)
+        }
+        return Plan(
+            clearFragmentRoot = true,
+            cleanPreferenceList = hasPreferenceList,
+        )
+    }
+}

--- a/app/src/main/java/tv/withaibuild/customiuizer/PreferenceFragmentBase.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/PreferenceFragmentBase.kt
@@ -29,6 +29,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.ListPreference
 import androidx.preference.PreferenceManager
+import androidx.recyclerview.widget.RecyclerView
 import java.util.Collections
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
@@ -520,20 +521,27 @@ open class PreferenceFragmentBase : PreferenceFragmentCompat() {
 
     /**
      * Finishes the source row's ripple before both fragments are translated side by side.
-     * Only currently attached rows are touched, so the work is bounded by the viewport and
-     * allocates no animator or long-lived state.
+     * Preference pages clean the visible RecyclerView rows. Edit pages have no Preference
+     * list; that is a valid state and only the fragment root is cleared.
      */
     private fun finishNavigationFeedback() {
         val fragmentView = view ?: return
-        fragmentView.isPressed = false
-        fragmentView.jumpDrawablesToCurrentState()
-
-        val preferenceList = getListView()
-        preferenceList.stopScroll()
-        preferenceList.isPressed = false
-        preferenceList.jumpDrawablesToCurrentState()
-        for (index in 0 until preferenceList.childCount) {
-            val row = preferenceList.getChildAt(index)
+        val preferenceList = getListView() as RecyclerView?
+        val plan = NavigationFeedback.plan(
+            hasFragmentView = true,
+            hasPreferenceList = preferenceList != null,
+        )
+        if (plan.clearFragmentRoot) {
+            fragmentView.isPressed = false
+            fragmentView.jumpDrawablesToCurrentState()
+        }
+        if (!plan.cleanPreferenceList) return
+        val list = preferenceList ?: return
+        list.stopScroll()
+        list.isPressed = false
+        list.jumpDrawablesToCurrentState()
+        for (index in 0 until list.childCount) {
+            val row = list.getChildAt(index)
             row.isPressed = false
             row.jumpDrawablesToCurrentState()
         }

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/GlobalActionToggles.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/GlobalActionToggles.kt
@@ -1,0 +1,35 @@
+package tv.withaibuild.customiuizer.mods
+
+/**
+ * MultiAction toggle IDs 1..12 map onto the existing GlobalActions Toggle* names.
+ * Transport is [GlobalActions.commonSendAction]; this table only names the action suffix.
+ */
+object GlobalActionToggles {
+
+    private val suffixes = arrayOf(
+        "WiFi",
+        "Bluetooth",
+        "GPS",
+        "NFC",
+        "SoundProfile",
+        "AutoBrightness",
+        "AutoRotation",
+        "Flashlight",
+        "MobileData",
+        "Hotspot",
+        "ZenMode",
+        "NightMode",
+    )
+
+    @JvmStatic
+    fun suffix(what: Int): String? = suffixes.getOrNull(what - 1)
+
+    @JvmStatic
+    fun broadcastAction(what: Int): String? {
+        val name = suffix(what) ?: return null
+        return "Toggle$name"
+    }
+
+    @JvmStatic
+    fun idCount(): Int = suffixes.size
+}

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/GlobalActions.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/GlobalActions.kt
@@ -735,25 +735,8 @@ object GlobalActions {
     }
 
     private fun toggleThis(context: Context, what: Int): Boolean {
-        return ModuleHelper.guarded(false) {
-            val whatStr = when (what) {
-                1 -> "WiFi"
-                2 -> "Bluetooth"
-                3 -> "GPS"
-                4 -> "NFC"
-                5 -> "SoundProfile"
-                6 -> "AutoBrightness"
-                7 -> "AutoRotation"
-                8 -> "Flashlight"
-                9 -> "MobileData"
-                10 -> "Hotspot"
-                11 -> "ZenMode"
-                12 -> "NightMode"
-                else -> return false
-            }
-            context.sendBroadcast(Intent(ACTION_PREFIX + "Toggle" + whatStr))
-            true
-        }
+        val action = GlobalActionToggles.broadcastAction(what) ?: return false
+        return commonSendAction(context, action)
     }
 
     @JvmStatic

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/LauncherGestureHooks.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/LauncherGestureHooks.kt
@@ -141,19 +141,14 @@ object LauncherGestureHooks {
                         if (skipped) { return XposedHelpers.throwOrReturn(throwable, result) }
                         return XposedHelpers.proceedOrThrow(chain, throwable)
                     }
-                    var key: String? = null
                     val helperContext = (thisObject as ViewGroup).context
                     var numOfFingers = 1
                     if (args[1] != null) numOfFingers = (args[1] as MotionEvent).pointerCount
-                    when (args[0] as Int) {
-                        11 -> {
-                            key = if (numOfFingers == 1) "launcher_swipedown" else if (numOfFingers == 2) "launcher_swipedown2" else key
-                            if (GlobalActions.handleAction(helperContext, key)) { skipped = true; result = true; throwable = null }
-                        }
-                        10 -> {
-                            key = if (numOfFingers == 1) "launcher_swipeup" else if (numOfFingers == 2) "launcher_swipeup2" else key
-                            if (GlobalActions.handleAction(helperContext, key)) { skipped = true; result = true; throwable = null }
-                        }
+                    val key = LauncherVerticalGesture.resolveKey(args[0] as Int, numOfFingers)
+                    if (key != null && GlobalActions.handleAction(helperContext, key)) {
+                        skipped = true
+                        result = true
+                        throwable = null
                     }
                     if (skipped) { return XposedHelpers.throwOrReturn(throwable, result) }
                     result = chain.proceed()

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/LauncherVerticalGesture.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/LauncherVerticalGesture.kt
@@ -1,0 +1,31 @@
+package tv.withaibuild.customiuizer.mods
+
+/**
+ * Workspace vertical-gesture key mapping used by [LauncherGestureHooks.HomescreenSwipesHook].
+ *
+ * Direction integers 10/11 are the module's assumed Workspace ABI. This resolver only
+ * proves mapping; it does not prove the current HyperOS [com.miui.home] still uses those
+ * codes or still delivers a two-pointer [android.view.MotionEvent] into onVerticalGesture.
+ */
+object LauncherVerticalGesture {
+
+    const val DIRECTION_UP = 10
+    const val DIRECTION_DOWN = 11
+
+    @JvmStatic
+    fun resolveKey(direction: Int, pointerCount: Int): String? {
+        return when (direction) {
+            DIRECTION_DOWN -> when (pointerCount) {
+                1 -> "launcher_swipedown"
+                2 -> "launcher_swipedown2"
+                else -> null
+            }
+            DIRECTION_UP -> when (pointerCount) {
+                1 -> "launcher_swipeup"
+                2 -> "launcher_swipeup2"
+                else -> null
+            }
+            else -> null
+        }
+    }
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -213,6 +213,7 @@
 		<item>@string/array_global_actions_launch</item>
 		<item>@string/array_global_actions_shortcut</item>
 		<item>@string/array_global_actions_activity</item>
+		<item>@string/array_global_actions_toggle</item>
 	</string-array>
 	<integer-array name="global_lockscreen_actions_val">
 		<item>1</item>

--- a/app/src/test/java/tv/withaibuild/customiuizer/NavigationFeedbackTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/NavigationFeedbackTest.kt
@@ -1,0 +1,131 @@
+package tv.withaibuild.customiuizer
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavigationFeedbackTest {
+
+    @Test
+    fun preferencePageWithRecyclerView_cleansRootAndList() {
+        val plan = NavigationFeedback.plan(hasFragmentView = true, hasPreferenceList = true)
+        assertTrue(plan.clearFragmentRoot)
+        assertTrue(plan.cleanPreferenceList)
+    }
+
+    @Test
+    fun editPageWithoutPreferenceList_cleansRootAndDoesNotTouchList() {
+        val plan = NavigationFeedback.plan(hasFragmentView = true, hasPreferenceList = false)
+        assertTrue(plan.clearFragmentRoot)
+        assertFalse(plan.cleanPreferenceList)
+    }
+
+    @Test
+    fun missingFragmentView_skipsAllCleanup() {
+        val plan = NavigationFeedback.plan(hasFragmentView = false, hasPreferenceList = false)
+        assertFalse(plan.clearFragmentRoot)
+        assertFalse(plan.cleanPreferenceList)
+    }
+
+    @Test
+    fun absentListIsALegalStateNotAnException() {
+        val plan = NavigationFeedback.plan(hasFragmentView = true, hasPreferenceList = false)
+        assertEquals(
+            NavigationFeedback.Plan(clearFragmentRoot = true, cleanPreferenceList = false),
+            plan,
+        )
+    }
+}
+
+class NavigationFeedbackWiringContractTest {
+
+    private val preferenceFragmentBase = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/PreferenceFragmentBase.kt")
+    )
+    private val subFragment = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/SubFragment.kt")
+    )
+
+    @Test
+    fun finishNavigationFeedbackUsesPlanAndDoesNotDereferenceAMissingList() {
+        val finish = section(
+            preferenceFragmentBase,
+            "private fun finishNavigationFeedback()",
+            "override fun onCreateAnimator",
+        )
+        assertTrue(finish.contains("NavigationFeedback.plan("))
+        assertTrue(finish.contains("getListView() as RecyclerView?"))
+        assertTrue(finish.contains("if (!plan.cleanPreferenceList) return"))
+        assertFalse(
+            Regex("""val preferenceList = getListView\(\)\s+preferenceList\.stopScroll\(\)""")
+                .containsMatchIn(finish),
+        )
+        assertTrue(finish.contains("list.stopScroll()"))
+    }
+
+    @Test
+    fun openSubFragmentStillGuardsSavedStateAndUsesOrdinaryCommit() {
+        val open = section(
+            preferenceFragmentBase,
+            "open fun openSubFragment(\n        fragment: Fragment,\n        args: Bundle?,\n        settingsType: AppHelper.SettingsType,\n        abType: AppHelper.ActionBarType,\n        title: String?,",
+            "private fun finishNavigationFeedback()",
+        )
+        assertTrue(open.contains("isStateSaved"))
+        assertTrue(open.contains(".commit()"))
+        assertTrue(open.contains("finishNavigationFeedback()"))
+        assertFalse(open.contains("commitAllowingStateLoss"))
+        assertFalse(open.contains("executePendingTransactions"))
+    }
+
+    @Test
+    fun editPagesDoNotCreateThePreferenceRecyclerView() {
+        val onCreateView = section(
+            subFragment,
+            "override fun onCreateView",
+            "override fun onViewCreated",
+        )
+        assertTrue(onCreateView.contains("settingsType == AppHelper.SettingsType.Preference"))
+        assertTrue(onCreateView.contains("super.onCreateView("))
+        assertTrue(onCreateView.contains("R.layout.prefs_common"))
+        assertFalse(onCreateView.contains("super.onCreateView(crtInflator, container, savedInstanceState)\n        } else {\n            super.onCreateView"))
+    }
+
+    @Test
+    fun editToChildSelectorsShareTheCommonOpenSubFragmentHelper() {
+        val files = listOf(
+            "src/main/java/tv/withaibuild/customiuizer/subs/MultiAction.kt",
+            "src/main/java/tv/withaibuild/customiuizer/subs/AppSelector.kt",
+            "src/main/java/tv/withaibuild/customiuizer/subs/SortableList.kt",
+            "src/main/java/tv/withaibuild/customiuizer/SubFragment.kt",
+            "src/main/java/tv/withaibuild/customiuizer/subs/System_NoScreenLock.kt",
+        )
+        for (file in files) {
+            val source = Files.readString(Path.of(file))
+            assertTrue("$file must open children through openSubFragment", source.contains("openSubFragment("))
+            assertFalse(
+                "$file must not implement a private navigation helper",
+                source.contains("fun finishNavigationFeedback"),
+            )
+        }
+        assertTrue(
+            Files.readString(Path.of("src/main/java/tv/withaibuild/customiuizer/subs/MultiAction.kt"))
+                .contains("SettingsType.Edit"),
+        )
+        assertTrue(
+            Files.readString(Path.of("src/main/java/tv/withaibuild/customiuizer/subs/AppSelector.kt"))
+                .contains("ActivitySelector()"),
+        )
+    }
+
+    private fun section(source: String, start: String, end: String): String {
+        val startIndex = source.indexOf(start)
+        val endIndex = source.indexOf(end, startIndex + start.length)
+        check(startIndex >= 0 && endIndex > startIndex) {
+            "Could not extract source section between '$start' and '$end'"
+        }
+        return source.substring(startIndex, endIndex)
+    }
+}

--- a/app/src/test/java/tv/withaibuild/customiuizer/PreferenceNavigationContractTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/PreferenceNavigationContractTest.kt
@@ -37,6 +37,7 @@ class PreferenceNavigationContractTest {
         assertTrue(stringOverload.contains("isStateSaved"))
         assertTrue(stringOverload.contains(".commit()"))
         assertFalse(stringOverload.contains("commitAllowingStateLoss"))
+        assertFalse(stringOverload.contains("executePendingTransactions"))
     }
 }
 

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/GlobalActionTogglesTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/GlobalActionTogglesTest.kt
@@ -1,0 +1,32 @@
+package tv.withaibuild.customiuizer.mods
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GlobalActionTogglesTest {
+
+    @Test
+    fun twelveToggleIdsMapOntoExistingToggleBroadcastNames() {
+        assertEquals(12, GlobalActionToggles.idCount())
+        val expected = listOf(
+            1 to "ToggleWiFi",
+            2 to "ToggleBluetooth",
+            3 to "ToggleGPS",
+            4 to "ToggleNFC",
+            5 to "ToggleSoundProfile",
+            6 to "ToggleAutoBrightness",
+            7 to "ToggleAutoRotation",
+            8 to "ToggleFlashlight",
+            9 to "ToggleMobileData",
+            10 to "ToggleHotspot",
+            11 to "ToggleZenMode",
+            12 to "ToggleNightMode",
+        )
+        for ((id, action) in expected) {
+            assertEquals(action, GlobalActionToggles.broadcastAction(id))
+        }
+        assertNull(GlobalActionToggles.broadcastAction(0))
+        assertNull(GlobalActionToggles.broadcastAction(13))
+    }
+}

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/LauncherGestureMatrixContractTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/LauncherGestureMatrixContractTest.kt
@@ -1,0 +1,101 @@
+package tv.withaibuild.customiuizer.mods
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LauncherGestureMatrixContractTest {
+
+    private val prefs = Files.readString(Path.of("src/main/res/xml/prefs_launcher.xml"))
+    private val launcherUi = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/subs/Launcher.kt")
+    )
+    private val features = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/utils/feature/LauncherPostAttachFeatures.kt")
+    )
+    private val hooks = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/LauncherGestureHooks.kt")
+    )
+    private val folders = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/LauncherFolderHooks.kt")
+    )
+    private val config = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/utils/GlobalActionConfig.kt")
+    )
+    private val shake = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/utils/ShakeManager.kt")
+    )
+
+    @Test
+    fun tenGestureUiKeysOpenMultiActionAndHaveRuntimeKeys() {
+        val uiKeys = listOf(
+            "pref_key_launcher_swipedown",
+            "pref_key_launcher_swipedown2",
+            "pref_key_launcher_swipeup",
+            "pref_key_launcher_swipeup2",
+            "pref_key_launcher_swiperight",
+            "pref_key_launcher_swipeleft",
+            "pref_key_launcher_shake",
+            "pref_key_launcher_doubletap",
+            "pref_key_launcher_pinch",
+            "pref_key_launcher_spread",
+        )
+        for (key in uiKeys) {
+            assertTrue("$key missing from prefs_launcher.xml", prefs.contains("android:key=\"$key\""))
+            assertTrue("$key missing MultiAction click", launcherUi.contains("\"$key\""))
+        }
+        val runtimeKeys = listOf(
+            "launcher_swipedown",
+            "launcher_swipedown2",
+            "launcher_swipeup",
+            "launcher_swipeup2",
+            "launcher_swiperight",
+            "launcher_swipeleft",
+            "launcher_shake",
+            "launcher_doubletap",
+            "launcher_pinch",
+            "launcher_spread",
+        )
+        for (key in runtimeKeys) {
+            assertTrue("$key missing from GlobalActionConfig", config.contains("\"$key\""))
+        }
+    }
+
+    @Test
+    fun verticalFourShareHomescreenSwipesFeatureAndResolver() {
+        assertTrue(features.contains("prefs.getInt(\"launcher_swipedown_action\", 1) != 1"))
+        assertTrue(features.contains("prefs.getInt(\"launcher_swipeup_action\", 1) != 1"))
+        assertTrue(features.contains("prefs.getInt(\"launcher_swipedown2_action\", 1) != 1"))
+        assertTrue(features.contains("prefs.getInt(\"launcher_swipeup2_action\", 1) != 1"))
+        assertTrue(features.contains("LauncherGestureHooks.HomescreenSwipesHook"))
+        assertTrue(hooks.contains("onVerticalGesture"))
+        assertTrue(hooks.contains("LauncherVerticalGesture.resolveKey("))
+        assertTrue(hooks.contains("GlobalActions.handleAction(helperContext, key)"))
+    }
+
+    @Test
+    fun remainingSixHaveDedicatedInstallersAndActionKeys() {
+        assertTrue(features.contains("prefs.getInt(\"launcher_swipeleft_action\", 1) != 1"))
+        assertTrue(features.contains("prefs.getInt(\"launcher_swiperight_action\", 1) != 1"))
+        assertTrue(features.contains("LauncherGestureHooks.HotSeatSwipesHook"))
+        assertTrue(hooks.contains("\"launcher_swipeleft\""))
+        assertTrue(hooks.contains("\"launcher_swiperight\""))
+
+        assertTrue(features.contains("prefs.getInt(\"launcher_shake_action\", 1) != 1"))
+        assertTrue(features.contains("LauncherGestureHooks.ShakeHook"))
+        assertTrue(shake.contains("handleAction(helperContext, \"pref_key_launcher_shake\")"))
+
+        assertTrue(features.contains("prefs.getInt(\"launcher_doubletap_action\", 1) != 1"))
+        assertTrue(features.contains("LauncherGestureHooks.LauncherDoubleTapHook"))
+        assertTrue(hooks.contains("DoubleTapController(args[0] as Context, \"launcher_doubletap\")"))
+
+        assertTrue(features.contains("prefs.getInt(\"launcher_pinch_action\", 1) != 1"))
+        assertTrue(features.contains("LauncherGestureHooks.LauncherPinchHook"))
+        assertTrue(hooks.contains("\"launcher_pinch\""))
+
+        assertTrue(features.contains("prefs.getBoolean(\"launcher_privacyapps_gest\") || prefs.getInt(\"launcher_spread_action\", 1) != 1"))
+        assertTrue(folders.contains("startSecurityHide"))
+        assertTrue(folders.contains("\"launcher_spread\""))
+    }
+}

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/LauncherVerticalGestureTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/LauncherVerticalGestureTest.kt
@@ -1,0 +1,37 @@
+package tv.withaibuild.customiuizer.mods
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LauncherVerticalGestureTest {
+
+    @Test
+    fun downAndUpMapOneAndTwoFingersToCanonicalKeys() {
+        assertEquals(
+            "launcher_swipedown",
+            LauncherVerticalGesture.resolveKey(LauncherVerticalGesture.DIRECTION_DOWN, 1),
+        )
+        assertEquals(
+            "launcher_swipedown2",
+            LauncherVerticalGesture.resolveKey(LauncherVerticalGesture.DIRECTION_DOWN, 2),
+        )
+        assertEquals(
+            "launcher_swipeup",
+            LauncherVerticalGesture.resolveKey(LauncherVerticalGesture.DIRECTION_UP, 1),
+        )
+        assertEquals(
+            "launcher_swipeup2",
+            LauncherVerticalGesture.resolveKey(LauncherVerticalGesture.DIRECTION_UP, 2),
+        )
+    }
+
+    @Test
+    fun otherDirectionsOrFingerCountsDoNotResolveACustomKey() {
+        assertNull(LauncherVerticalGesture.resolveKey(9, 1))
+        assertNull(LauncherVerticalGesture.resolveKey(12, 1))
+        assertNull(LauncherVerticalGesture.resolveKey(LauncherVerticalGesture.DIRECTION_DOWN, 0))
+        assertNull(LauncherVerticalGesture.resolveKey(LauncherVerticalGesture.DIRECTION_DOWN, 3))
+        assertNull(LauncherVerticalGesture.resolveKey(LauncherVerticalGesture.DIRECTION_UP, 3))
+    }
+}

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/ToggleIdentityContractTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/ToggleIdentityContractTest.kt
@@ -1,0 +1,60 @@
+package tv.withaibuild.customiuizer.mods
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToggleIdentityContractTest {
+
+    private val globalActions = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/GlobalActions.kt")
+    )
+    private val systemServerHooks = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/GlobalActionSystemServerHooks.kt")
+    )
+
+    @Test
+    fun toggleThisUsesIdentityAwareCommonSendAction() {
+        val toggleThis = section(globalActions, "private fun toggleThis", "fun isMediaActionsAllowed")
+        assertTrue(toggleThis.contains("GlobalActionToggles.broadcastAction(what)"))
+        assertTrue(toggleThis.contains("commonSendAction(context, action)"))
+        assertFalse(toggleThis.contains("sendBroadcast("))
+        assertTrue(globalActions.contains("fun commonSendAction") && globalActions.contains("sendBroadcastWithIdentity"))
+    }
+
+    @Test
+    fun allTwelveToggleBroadcastsAreRegisteredOnTheHostReceiver() {
+        val expected = listOf(
+            "ToggleWiFi",
+            "ToggleBluetooth",
+            "ToggleGPS",
+            "ToggleNFC",
+            "ToggleSoundProfile",
+            "ToggleAutoBrightness",
+            "ToggleAutoRotation",
+            "ToggleFlashlight",
+            "ToggleMobileData",
+            "ToggleHotspot",
+            "ToggleZenMode",
+            "ToggleNightMode",
+        )
+        val hostReceivers = globalActions + "\n" + systemServerHooks
+        for (action in expected) {
+            assertTrue(
+                "host receiver missing $action",
+                hostReceivers.contains("+ \"$action\""),
+            )
+        }
+    }
+
+    private fun section(source: String, start: String, end: String): String {
+        val startIndex = source.indexOf(start)
+        val endIndex = source.indexOf(end, startIndex + start.length)
+        check(startIndex >= 0 && endIndex > startIndex) {
+            "Could not extract source section between '$start' and '$end'"
+        }
+        return source.substring(startIndex, endIndex)
+    }
+}

--- a/app/src/test/java/tv/withaibuild/customiuizer/subs/MultiActionArrayContractTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/subs/MultiActionArrayContractTest.kt
@@ -1,0 +1,151 @@
+package tv.withaibuild.customiuizer.subs
+
+import java.nio.file.Files
+import java.nio.file.Path
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tv.withaibuild.customiuizer.mods.GlobalActionToggles
+
+class MultiActionArrayContractTest {
+
+    private val arrays = Files.readString(Path.of("src/main/res/values/arrays.xml"))
+    private val globalActions = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/GlobalActions.kt")
+    )
+    private val intentHelper = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/mods/GlobalActionsIntentHelper.kt")
+    )
+    private val multiAction = Files.readString(
+        Path.of("src/main/java/tv/withaibuild/customiuizer/subs/MultiAction.kt")
+    )
+
+    private val actionArrays = listOf(
+        "global_actions_launcher",
+        "global_actions_navbar",
+        "global_actions_controls",
+        "global_actions_statusbar",
+        "global_lockscreen_actions",
+        "global_launch_actions",
+    )
+
+    @Test
+    fun advertisedActionIdsHaveHandlersExceptNone() {
+        val handled = handledActionIds()
+        for (name in actionArrays) {
+            for (id in integerItems("${name}_val")) {
+                if (id <= 1) continue
+                assertTrue(
+                    "$name advertises action $id with no handler",
+                    id in handled,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun actionArraysHaveMatchingEntryAndValueCounts() {
+        for (name in actionArrays) {
+            assertEquals(
+                name,
+                stringItemCount(name),
+                integerItems("${name}_val").size,
+            )
+        }
+    }
+
+    @Test
+    fun lockscreenArrayIncludesToggleAlignedWithValueTen() {
+        assertEquals(6, stringItemCount("global_lockscreen_actions"))
+        assertEquals(
+            listOf(1, 12, 8, 9, 20, 10),
+            integerItems("global_lockscreen_actions_val"),
+        )
+        val entries = items("global_lockscreen_actions", "string-array")
+        assertEquals("@string/array_global_actions_toggle", entries.last())
+    }
+
+    @Test
+    fun launcherAdvertisesTheExpectedActionMatrix() {
+        assertEquals(
+            listOf(1, 2, 3, 4, 5, 6, 7, 17, 12, 26, 8, 9, 20, 10, 13, 14, 22, 23),
+            integerItems("global_actions_launcher_val"),
+        )
+    }
+
+    @Test
+    fun parameterizedActionsHaveUiAndMatchingPreferenceSuffixes() {
+        val controls = section(multiAction, "private fun updateControls", "override fun onActivityResult")
+        assertTrue(controls.contains("8 -> apps.visibility"))
+        assertTrue(controls.contains("9 -> shortcuts.visibility"))
+        assertTrue(controls.contains("10 -> toggles.visibility"))
+        assertTrue(controls.contains("20 -> activities.visibility"))
+
+        assertTrue(multiAction.contains("mKey + \"_app\""))
+        assertTrue(multiAction.contains("mKey + \"_shortcut\""))
+        assertTrue(multiAction.contains("mKey + \"_activity\""))
+        assertTrue(multiAction.contains("mKey + \"_toggle\""))
+        assertTrue(multiAction.contains("mKey + \"_app_user\""))
+        assertTrue(multiAction.contains("mKey + \"_activity_user\""))
+        assertTrue(multiAction.contains("mKey + \"_shortcut_intent\""))
+
+        assertTrue(intentHelper.contains("IntentType.APP -> \"_app\""))
+        assertTrue(intentHelper.contains("IntentType.ACTIVITY -> \"_activity\""))
+        assertTrue(intentHelper.contains("IntentType.SHORTCUT -> \"_shortcut_intent\""))
+        assertTrue(globalActions.contains("key + \"_toggle\""))
+    }
+
+    @Test
+    fun toggleValuesHaveImplementations() {
+        val toggleValues = integerItems("global_toggles_val")
+        assertEquals(stringItemCount("global_toggles"), toggleValues.size)
+        val mapping = Files.readString(
+            Path.of("src/main/java/tv/withaibuild/customiuizer/mods/GlobalActionToggles.kt")
+        )
+        assertEquals(12, toggleValues.size)
+        assertTrue(mapping.contains("\"WiFi\""))
+        assertTrue(mapping.contains("\"NightMode\""))
+        for (id in toggleValues) {
+            assertTrue("toggle $id has no mapping", GlobalActionToggles.broadcastAction(id) != null)
+        }
+    }
+
+    private fun handledActionIds(): Set<Int> {
+        val resolved = section(globalActions, "private fun executeResolvedAction", "fun getActionResId")
+        val ids = Regex("""^\s+(\d+) -> """, RegexOption.MULTILINE)
+            .findAll(resolved)
+            .map { it.groupValues[1].toInt() }
+            .toMutableSet()
+        val media = Regex("""action in (\d+)\.\.(\d+)""").find(globalActions)
+        if (media != null) {
+            val start = media.groupValues[1].toInt()
+            val end = media.groupValues[2].toInt()
+            ids.addAll(start..end)
+        }
+        return ids
+    }
+
+    private fun stringItemCount(name: String): Int = items(name, "string-array").size
+
+    private fun integerItems(name: String): List<Int> =
+        items(name, "integer-array").map { it.trim().toInt() }
+
+    private fun items(name: String, tag: String): List<String> {
+        val start = arrays.indexOf("<$tag name=\"$name\">")
+        val end = arrays.indexOf("</$tag>", start)
+        check(start >= 0 && end > start) { "Missing $tag $name" }
+        return Regex("""<item>(.*?)</item>""")
+            .findAll(arrays.substring(start, end))
+            .map { it.groupValues[1] }
+            .toList()
+    }
+
+    private fun section(source: String, start: String, end: String): String {
+        val startIndex = source.indexOf(start)
+        val endIndex = source.indexOf(end, startIndex + start.length)
+        check(startIndex >= 0 && endIndex > startIndex) {
+            "Could not extract source section between '$start' and '$end'"
+        }
+        return source.substring(startIndex, endIndex)
+    }
+}


### PR DESCRIPTION
## Summary
- Restore Edit-page selector navigation, MultiAction Toggle identity transport, and lockscreen action label/value alignment.
- Add launcher gesture and MultiAction contract tests.
- Bump release metadata to r14.20.7 / 204.

## Test plan
- [x] targeted contract tests
- [x] `python tools/verify.py fast --changed`
- [ ] `python tools/verify.py full`
- [ ] GitHub Fast CI
- [ ] GitHub Full CI on candidate SHA 134be630
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tomthenpc/customiuizer-a14/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->