### PR TITLE
r14.20.9: prefs lifecycle, WM isolation, CI scanner names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 English | [简体中文](CHANGELOG_CN.md)
 
+## r14.20.9 — 2026-09-05
+
+Prerelease. Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.
+
+### Stability
+
+- system_server no longer installs preference-gated features before the remote snapshot is ready. The first `LOADED` snapshot installs only features that are still not installed.
+- A fast SystemUI restart no longer skips the whole hook catalog, so killing SystemUI to apply settings actually installs those hooks.
+- WindowManager hot-path type errors are isolated in the hook. Constructor flags are resolved by parameter type instead of a hard-coded `args[2]`.
+- Custom status-bar height resource replacement is limited to `android`, SystemUI, and the launcher. The window height itself remains a system_server insets/layout change.
+
+### Artifact Information
+
+- APK: `CustoMIUIzer-A14-r14.20.9.apk`
+- versionCode / versionName: `206 / r14.20.9`
+
+---
+
 ## r14.20.8 — 2026-08-19
 
 Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -2,6 +2,24 @@
 
 [English](CHANGELOG.md) | 简体中文
 
+## r14.20.9 — 2026-09-05
+
+预发布。面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。
+
+### 稳定性
+
+- system_server 在偏好快照未就绪时不再安装业务功能；快照首次加载后再补装尚未安装的功能。
+- SystemUI 快速重启不再跳过整份 Hook catalog，避免杀进程应用设置后功能未生效。
+- WindowManager 热路径上的类型错误不再打穿系统窗口管理；构造函数按参数类型定位 flags。
+- 自定义状态栏高度的资源替换只进入 `android`、系统界面和桌面；窗口高度仍由 system_server 的 insets / layout 生效。
+
+### 产物信息
+
+- APK：`CustoMIUIzer-A14-r14.20.9.apk`
+- versionCode / versionName：`206 / r14.20.9`
+
+---
+
 ## r14.20.8 — 2026-08-19
 
 面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 CustoMIUIzer A14 是面向 **HyperOS 1 / Android 14（SDK 34）** 的系统界面与交互定制模块，基于 CustoMIUIzer 项目持续维护。它使用独立包名和版本线，不是上游官方版本。
 
 - 当前正式版：`r14.20.8`
+- 当前预发布：`r14.20.9`
 - 应用 ID：`tv.withaibuild.customiuizer.r14`
 - 源码仓库：<https://github.com/tomthenpc/customiuizer-a14>
 - 用户下载：<https://github.com/Xposed-Modules-Repo/tv.withaibuild.customiuizer.r14/releases>

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,6 +5,7 @@
 CustoMIUIzer A14 is a system UI and interaction customization module maintained for **HyperOS 1 / Android 14 (SDK 34)**. It has an independent package and release line and is not an official upstream release.
 
 - Current release: `r14.20.8`
+- Current prerelease: `r14.20.9`
 - Application ID: `tv.withaibuild.customiuizer.r14`
 - Source: <https://github.com/tomthenpc/customiuizer-a14>
 - User downloads: <https://github.com/Xposed-Modules-Repo/tv.withaibuild.customiuizer.r14/releases>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ if (officialRelease) {
     }
 }
 
-val lastVersion = 205
-val lastVersionName = "r14.20.8"
+val lastVersion = 206
+val lastVersionName = "r14.20.9"
 
 fun resolveBuildRevision(): String {
     val prop = project.findProperty("buildRevision")?.toString()

--- a/app/src/main/java/tv/withaibuild/customiuizer/installers/SystemUiInstaller.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/installers/SystemUiInstaller.kt
@@ -15,7 +15,8 @@ import tv.withaibuild.customiuizer.utils.PrefMap
  * This keeps [tv.withaibuild.customiuizer.MainModule] focused on module-level lifecycle
  * and delegates the long list of package-specific SystemUI hooks to a dedicated, stateless class.
  * Base hooks (SystemUIInitializer.init, fast-reboot receiver, status-bar setup and the 10-second
- * restart guard) stay in MainModule so the installer receives an already-validated load point.
+ * restart diagnostic) stay in SystemUiBootstrapCoordinator so the installer receives an
+ * already-validated load point. The 10-second window does not skip this catalog.
  */
 object SystemUiInstaller {
 

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/GlobalActionSystemServerHooks.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/GlobalActionSystemServerHooks.kt
@@ -27,6 +27,7 @@ import tv.withaibuild.customiuizer.mods.utils.HookerClassHelper.BeforeHookCallba
 import tv.withaibuild.customiuizer.mods.utils.HookerClassHelper.MethodHook
 import tv.withaibuild.customiuizer.mods.utils.ModuleHelper
 import tv.withaibuild.customiuizer.mods.utils.SystemServerPreferenceInvalidation
+import tv.withaibuild.customiuizer.mods.utils.SystemServerInstaller
 import tv.withaibuild.customiuizer.mods.utils.XposedHelpers
 import tv.withaibuild.customiuizer.mods.utils.hasConfiguredActionCode
 import tv.withaibuild.customiuizer.mods.utils.hasConfiguredToggle
@@ -576,6 +577,8 @@ object GlobalActionSystemServerHooks {
                 val mContext = XposedHelpers.getObjectField(thisObject, "mContext") as Context
                 MainModule.sPreferenceBootstrap?.let { bootstrap ->
                     SystemServerPreferenceInvalidation.install(mContext, bootstrap)
+                    bootstrap.bootstrap()
+                    SystemServerInstaller.installPendingIfPrefsLoaded()
                 }
                 val intentfilter = IntentFilter()
                 intentfilter.addAction(GlobalActions.ACTION_PREFIX + "SimulateMenu")

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/SystemSecurityHooks.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/SystemSecurityHooks.kt
@@ -3,6 +3,7 @@ package tv.withaibuild.customiuizer.mods
 import android.content.pm.ApplicationInfo
 import io.github.libxposed.api.XposedInterface
 import io.github.libxposed.api.XposedModuleInterface.SystemServerStartingParam
+import tv.withaibuild.customiuizer.mods.utils.FatalErrors
 import tv.withaibuild.customiuizer.mods.utils.HookerClassHelper
 import tv.withaibuild.customiuizer.mods.utils.HookerClassHelper.MethodHook
 import tv.withaibuild.customiuizer.mods.utils.ModuleHelper
@@ -180,39 +181,25 @@ object SystemSecurityHooks {
         ModuleHelper.findAndHookMethod("com.android.server.wm.WindowState", lpparam.classLoader, "isSecureLocked", HookerClassHelper.returnConstant(false))
         ModuleHelper.findAndHookMethod("com.android.server.wm.WindowSurfaceController", lpparam.classLoader, "setSecure", Boolean::class.javaPrimitiveType!!, object : MethodHook() {
             override fun intercept(chain: XposedInterface.Chain): Any? {
-                var result: Any? = null
-                var throwable: Throwable? = null
-                val args = XposedHelpers.getArgsArray(chain)
+                var proceedArgs: Array<Any?>? = null
                 try {
-
-                    args[0] = false
-
-                    result = chain.proceed(args)
+                    if (chain.getArg(0) is Boolean) {
+                        val args = XposedHelpers.getArgsArray(chain)
+                        args[0] = false
+                        proceedArgs = args
+                    }
                 } catch (t: Throwable) {
-                    throwable = t
-                    result = null
+                    FatalErrors.unwrapAndRethrowIfFatal(t)
+                    XposedHelpers.log(t)
                 }
-                return XposedHelpers.throwOrReturn(throwable, result)
+                return if (proceedArgs != null) chain.proceed(proceedArgs) else chain.proceed()
             }
         })
         ModuleHelper.hookAllConstructors("com.android.server.wm.WindowSurfaceController", lpparam.classLoader, object : MethodHook() {
             override fun intercept(chain: XposedInterface.Chain): Any? {
-                var result: Any? = null
-                var throwable: Throwable? = null
-                val args = XposedHelpers.getArgsArray(chain)
-                try {
-
-                    var flags = args[2] as Int
-                    val secureFlag = 128
-                    flags = flags and secureFlag.inv()
-                    args[2] = flags
-
-                    result = chain.proceed(args)
-                } catch (t: Throwable) {
-                    throwable = t
-                    result = null
+                return WindowSurfaceControlArgs.interceptFlags(chain) { flags, _ ->
+                    flags and WindowSurfaceControlArgs.FLAG_SECURE.inv()
                 }
-                return XposedHelpers.throwOrReturn(throwable, result)
             }
         })
         ModuleHelper.hookAllMethods("com.android.server.wm.WindowManagerServiceImpl", lpparam.classLoader, "notAllowCaptureDisplay", object : MethodHook() {

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/SystemStatusBarInsetsHooks.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/SystemStatusBarInsetsHooks.kt
@@ -265,7 +265,7 @@ object SystemStatusBarInsetsHooks {
         private val effect: StatusBarHeightEffect,
     ) : MethodHook() {
         override fun intercept(chain: XposedInterface.Chain): Any? {
-            return onLayoutWindowLw(chain, effect)
+            return isolateWindowManagerHook(chain) { onLayoutWindowLw(chain, effect) }
         }
     }
 
@@ -321,7 +321,7 @@ object SystemStatusBarInsetsHooks {
         private val effect: StatusBarHeightEffect,
     ) : MethodHook() {
         override fun intercept(chain: XposedInterface.Chain): Any? {
-            return onSetFrames(chain, effect)
+            return isolateWindowManagerHook(chain) { onSetFrames(chain, effect) }
         }
     }
 
@@ -361,7 +361,29 @@ object SystemStatusBarInsetsHooks {
         private val effect: StatusBarHeightEffect,
     ) : MethodHook() {
         override fun intercept(chain: XposedInterface.Chain): Any? {
-            return onDecorInsetsInfoUpdate(chain, effect)
+            return isolateWindowManagerHook(chain) { onDecorInsetsInfoUpdate(chain, effect) }
+        }
+    }
+
+    /**
+     * ClassCast / NPE / OOB in a WM callback must not escape into WindowManager.
+     * Host exceptions from `chain.proceed()` inside [block] still propagate.
+     */
+    private inline fun isolateWindowManagerHook(
+        chain: XposedInterface.Chain,
+        block: () -> Any?,
+    ): Any? {
+        return try {
+            block()
+        } catch (t: ClassCastException) {
+            XposedHelpers.log(t)
+            chain.proceed()
+        } catch (t: NullPointerException) {
+            XposedHelpers.log(t)
+            chain.proceed()
+        } catch (t: IndexOutOfBoundsException) {
+            XposedHelpers.log(t)
+            chain.proceed()
         }
     }
 

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/SystemWindowHooks.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/SystemWindowHooks.kt
@@ -14,6 +14,7 @@ import io.github.libxposed.api.XposedInterface
 import io.github.libxposed.api.XposedModuleInterface.PackageReadyParam
 import io.github.libxposed.api.XposedModuleInterface.SystemServerStartingParam
 import tv.withaibuild.customiuizer.MainModule
+import tv.withaibuild.customiuizer.mods.utils.FatalErrors
 import tv.withaibuild.customiuizer.mods.utils.HookerClassHelper
 import tv.withaibuild.customiuizer.mods.utils.HookerClassHelper.MethodHook
 import tv.withaibuild.customiuizer.mods.utils.ModuleHelper
@@ -240,30 +241,19 @@ object SystemWindowHooks {
 
     @JvmStatic
     fun TempHideOverlayAppHook(lpparam: SystemServerStartingParam) {
-        val flagIndex = 2
         ModuleHelper.hookAllConstructors("com.android.server.wm.WindowSurfaceController", lpparam.classLoader, object : MethodHook() {
             override fun intercept(chain: XposedInterface.Chain): Any? {
-                var result: Any? = null
-                var throwable: Throwable? = null
-                try {
-
-                    val windowType = chain.getArg(4) as Int
+                return WindowSurfaceControlArgs.interceptFlags(chain) { flags, windowType ->
                     if (windowType != WindowManager.LayoutParams.TYPE_PHONE
                         && windowType != WindowManager.LayoutParams.TYPE_SYSTEM_OVERLAY
                         && windowType != WindowManager.LayoutParams.TYPE_SYSTEM_ALERT
-                        && windowType != WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY) { return XposedHelpers.proceedOrThrow(chain, throwable) }
-                    val args = XposedHelpers.getArgsArray(chain)
-                    var flags = args[flagIndex] as Int
-                    val skipFlag = 64
-                    flags = flags or skipFlag
-                    args[flagIndex] = flags
-
-                    result = chain.proceed(args)
-                } catch (t: Throwable) {
-                    throwable = t
-                    result = null
+                        && windowType != WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                    ) {
+                        null
+                    } else {
+                        flags or WindowSurfaceControlArgs.SKIP_SCREENSHOT
+                    }
                 }
-                return XposedHelpers.throwOrReturn(throwable, result)
             }
         })
     }
@@ -576,30 +566,25 @@ object SystemWindowHooks {
     fun AllowUntrustedTouchHook(lpparam: SystemServerStartingParam) {
         ModuleHelper.findAndHookMethod("com.android.server.wm.WindowState", lpparam.classLoader, "getTouchOcclusionMode", object : MethodHook() {
             override fun intercept(chain: XposedInterface.Chain): Any? {
-                var result: Any?
-                var throwable: Throwable? = null
-                try {
-                    result = chain.proceed()
+                val original = try {
+                    chain.proceed()
                 } catch (t: Throwable) {
-                    throwable = t
-                    result = null
+                    FatalErrors.unwrapAndRethrowIfFatal(t)
+                    throw t
                 }
-                try {
-                    val thisObject = chain.thisObject
-
-                    val mode = result as Int
-                    if (mode == 1) { result = 2; throwable = null }
-                    else {
-                        val mAttrs = XposedHelpers.getObjectField(thisObject, "mAttrs") as WindowManager.LayoutParams
-                        if (mAttrs.type == WindowManager.LayoutParams.TYPE_TOAST) {
-                            result = 2; throwable = null
-                        }
+                return try {
+                    val mode = original as? Int ?: return original
+                    if (mode == 1) {
+                        2
+                    } else {
+                        val mAttrs = XposedHelpers.getObjectField(chain.thisObject, "mAttrs") as? WindowManager.LayoutParams
+                        if (mAttrs?.type == WindowManager.LayoutParams.TYPE_TOAST) 2 else original
                     }
-
                 } catch (t: Throwable) {
+                    FatalErrors.unwrapAndRethrowIfFatal(t)
                     XposedHelpers.log(t)
+                    original
                 }
-                return XposedHelpers.throwOrReturn(throwable, result)
             }
         })
     }

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/WindowSurfaceControlArgs.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/WindowSurfaceControlArgs.kt
@@ -1,0 +1,93 @@
+package tv.withaibuild.customiuizer.mods
+
+import io.github.libxposed.api.XposedInterface
+import tv.withaibuild.customiuizer.mods.utils.FatalErrors
+import tv.withaibuild.customiuizer.mods.utils.XposedHelpers
+import java.lang.reflect.Constructor
+
+/**
+ * Resolves [com.android.server.wm.WindowSurfaceController] constructor slots by parameter
+ * type, never by a hard-coded `args[2] as Int`.
+ *
+ * AOSP 12+ constructs the surface from a Builder and has no flags argument; mutating
+ * `args[2]` there would rewrite `windowType`. Unknown shapes fail closed: the hook
+ * proceeds unchanged and `setSecure` remains the FLAG_SECURE path.
+ */
+internal object WindowSurfaceControlArgs {
+    const val FLAG_SECURE = 0x80
+    const val SKIP_SCREENSHOT = 0x40
+
+    private val INT = Int::class.javaPrimitiveType!!
+
+    fun parameterTypes(chain: XposedInterface.Chain): Array<Class<*>>? {
+        val member = chain.executable ?: return null
+        return (member as? Constructor<*>)?.parameterTypes
+    }
+
+    /**
+     * Index of the SurfaceControl flags `int`, or `-1` if this constructor has none.
+     *
+     * - AOSP 10/11: `(String name, int w, int h, int format, int flags, …)` → 4
+     * - MIUI HyperOS historical contract: flags at 2, windowType at 4
+     */
+    fun flagsIndex(types: Array<Class<*>>): Int {
+        if (isAospLegacySurfaceConstructor(types)) return 4
+        if (isMiuiFlagsAtTwo(types)) return 2
+        return -1
+    }
+
+    /**
+     * Index of the window type `int` used by overlay filtering, or `-1` if unknown.
+     */
+    fun windowTypeIndex(types: Array<Class<*>>, flagsIndex: Int): Int {
+        if (flagsIndex == 4 && types.size >= 7 && types[6] == INT) return 6
+        if (flagsIndex == 2 && types.size >= 5 && types[4] == INT) return 4
+        return -1
+    }
+
+    /**
+     * Mutates SurfaceControl flags when the constructor actually has them.
+     *
+     * [transform] receives the current flags and the resolved window type (nullable).
+     * Return `null` to leave the constructor unmodified. ClassCast / NPE / OOB in the
+     * hook body are logged; the original constructor still runs. Exceptions from
+     * `chain.proceed()` propagate to the host unchanged.
+     */
+    fun interceptFlags(
+        chain: XposedInterface.Chain,
+        transform: (flags: Int, windowType: Int?) -> Int?,
+    ): Any? {
+        var proceedArgs: Array<Any?>? = null
+        try {
+            val types = parameterTypes(chain) ?: return chain.proceed()
+            val flagsSlot = flagsIndex(types)
+            if (flagsSlot < 0) return chain.proceed()
+            val flags = chain.getArg(flagsSlot)
+            if (flags !is Int) return chain.proceed()
+            val windowTypeIndex = windowTypeIndex(types, flagsSlot)
+            val windowType = if (windowTypeIndex >= 0) chain.getArg(windowTypeIndex) as? Int else null
+            val newFlags = transform(flags, windowType) ?: return chain.proceed()
+            if (newFlags == flags) return chain.proceed()
+            val args = XposedHelpers.getArgsArray(chain)
+            args[flagsSlot] = newFlags
+            proceedArgs = args
+        } catch (t: Throwable) {
+            FatalErrors.unwrapAndRethrowIfFatal(t)
+            XposedHelpers.log(t)
+        }
+        return if (proceedArgs != null) chain.proceed(proceedArgs) else chain.proceed()
+    }
+
+    private fun isAospLegacySurfaceConstructor(types: Array<Class<*>>): Boolean {
+        return types.size >= 5 &&
+            types[0] == String::class.java &&
+            types[1] == INT &&
+            types[2] == INT &&
+            types[3] == INT &&
+            types[4] == INT
+    }
+
+    private fun isMiuiFlagsAtTwo(types: Array<Class<*>>): Boolean {
+        return types.size >= 5 && types[2] == INT && types[4] == INT
+    }
+}

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerInstaller.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerInstaller.kt
@@ -36,8 +36,8 @@ object SystemServerInstaller {
         val mPrefs = MainModule.mPrefs
 
         synchronized(lock) {
-            val activeRegistry = registry ?: run {
-                val created = FeatureInstallRegistry()
+            val registry = this.registry ?: run {
+                val registry = FeatureInstallRegistry()
                 val catalogStartNanos = FeatureInstallMetrics.nowNanos()
                 val catalogStartBytes = FeatureInstallMetrics.allocatedBytes()
                 val packagePermissionsFeature = PackagePermissionsFeature(lpparam, mPrefs)
@@ -46,11 +46,11 @@ object SystemServerInstaller {
                 val catalogEndBytes = FeatureInstallMetrics.allocatedBytes()
                 val registerStartNanos = FeatureInstallMetrics.nowNanos()
                 val registerStartBytes = FeatureInstallMetrics.allocatedBytes()
-                created.register(packagePermissionsFeature)
+                registry.register(packagePermissionsFeature)
 
                 // All preference-guarded system_server features.
                 for (feature in features) {
-                    created.register(feature)
+                    registry.register(feature)
                 }
 
                 val registerEndNanos = FeatureInstallMetrics.nowNanos()
@@ -73,14 +73,14 @@ object SystemServerInstaller {
                 // changes do not require restarting system_server. ROM-specific optional
                 // hooks remain lazy inside setupStatusBar.
                 GlobalActionSystemServerHooks.setupGlobalActions(lpparam)
-                registry = created
-                created
+                this.registry = registry
+                registry
             }
 
             // Unready snapshots must not decide business features. Always-on specs
             // (preferenceKey null / isEnabled on an empty map) still install.
             val installPrefs = if (prefReady) mPrefs else PrefMap()
-            activeRegistry.installAll(FeatureTarget.SYSTEM_SERVER, InstallPhase.SYSTEM_SERVER_STARTING, installPrefs)
+            registry.installAll(FeatureTarget.SYSTEM_SERVER, InstallPhase.SYSTEM_SERVER_STARTING, installPrefs)
             if (SystemServerPrefLifecycle.shouldMarkCatchUpComplete(prefReady, currentBootstrapState())) {
                 catchUpDone = true
             }
@@ -98,8 +98,8 @@ object SystemServerInstaller {
             if (!SystemServerPrefLifecycle.shouldRunCatchUp(catchUpDone, currentBootstrapState())) {
                 return
             }
-            val activeRegistry = registry ?: return
-            activeRegistry.installAll(
+            val registry = this.registry ?: return
+            registry.installAll(
                 FeatureTarget.SYSTEM_SERVER,
                 InstallPhase.SYSTEM_SERVER_STARTING,
                 MainModule.mPrefs,

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerInstaller.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerInstaller.kt
@@ -1,5 +1,7 @@
 package tv.withaibuild.customiuizer.mods.utils
 
+import android.content.Context
+import android.os.Handler
 import io.github.libxposed.api.XposedModuleInterface
 import tv.withaibuild.customiuizer.MainModule
 import tv.withaibuild.customiuizer.mods.GlobalActionSystemServerHooks
@@ -7,61 +9,120 @@ import tv.withaibuild.customiuizer.mods.PackagePermissions
 import tv.withaibuild.customiuizer.mods.utils.feature.PackagePermissionsFeatureId
 import tv.withaibuild.customiuizer.mods.utils.feature.SystemServerFeatures
 import tv.withaibuild.customiuizer.utils.PrefMap
+
 /**
  * Installer for hooks that must run in `system_server`.
  *
  * This keeps [MainModule] focused on module-level lifecycle and delegates the long list of
- * per-preference system-server hooks to a dedicated, stateless object.  Each hook is still guarded
+ * per-preference system-server hooks to a dedicated object.  Each hook is still guarded
  * by the same preference check; nothing is installed unless the user has enabled it.
+ *
+ * Preference-gated features are not decided against a torn/empty snapshot. When
+ * [prefReady] is false they stay [FeatureState.NOT_INSTALLED]. The first
+ * [PreferenceBootstrap.State.LOADED] snapshot runs [installAll] again for those
+ * features only — already-installed hooks are never reinstalled.
  */
 object SystemServerInstaller {
 
+    private val lock = Any()
+    private var registry: FeatureInstallRegistry? = null
+
+    @Volatile
+    private var catchUpDone = false
+
     @JvmStatic
     @JvmOverloads
-    @Suppress("UNUSED_PARAMETER")
     fun install(lpparam: XposedModuleInterface.SystemServerStartingParam, prefReady: Boolean = true) {
         val mPrefs = MainModule.mPrefs
 
-        // Base system_server hook: not preference-controlled, always installed.
-        val registry = FeatureInstallRegistry()
-        val catalogStartNanos = FeatureInstallMetrics.nowNanos()
-        val catalogStartBytes = FeatureInstallMetrics.allocatedBytes()
-        val packagePermissionsFeature = PackagePermissionsFeature(lpparam, mPrefs)
-        val features = SystemServerFeatures.all(lpparam)
-        val catalogEndNanos = FeatureInstallMetrics.nowNanos()
-        val catalogEndBytes = FeatureInstallMetrics.allocatedBytes()
-        val registerStartNanos = FeatureInstallMetrics.nowNanos()
-        val registerStartBytes = FeatureInstallMetrics.allocatedBytes()
-        registry.register(packagePermissionsFeature)
+        synchronized(lock) {
+            val activeRegistry = registry ?: run {
+                val created = FeatureInstallRegistry()
+                val catalogStartNanos = FeatureInstallMetrics.nowNanos()
+                val catalogStartBytes = FeatureInstallMetrics.allocatedBytes()
+                val packagePermissionsFeature = PackagePermissionsFeature(lpparam, mPrefs)
+                val features = SystemServerFeatures.all(lpparam)
+                val catalogEndNanos = FeatureInstallMetrics.nowNanos()
+                val catalogEndBytes = FeatureInstallMetrics.allocatedBytes()
+                val registerStartNanos = FeatureInstallMetrics.nowNanos()
+                val registerStartBytes = FeatureInstallMetrics.allocatedBytes()
+                created.register(packagePermissionsFeature)
 
-        // All preference-guarded system_server features.
-        for (feature in features) {
-            registry.register(feature)
+                // All preference-guarded system_server features.
+                for (feature in features) {
+                    created.register(feature)
+                }
+
+                val registerEndNanos = FeatureInstallMetrics.nowNanos()
+                val registerEndBytes = FeatureInstallMetrics.allocatedBytes()
+                FeatureInstallMetrics.recordCatalog(
+                    label = "system-server/starting",
+                    specCount = features.size + 1,
+                    catalogStartNanos = catalogStartNanos,
+                    catalogEndNanos = catalogEndNanos,
+                    catalogStartBytes = catalogStartBytes,
+                    catalogEndBytes = catalogEndBytes,
+                    registerStartNanos = registerStartNanos,
+                    registerEndNanos = registerEndNanos,
+                    registerStartBytes = registerStartBytes,
+                    registerEndBytes = registerEndBytes,
+                )
+
+                // PhoneWindowManager GlobalAction receiver is a cheap always-on transport.
+                // It must be installed at system_server start so later none → configured
+                // changes do not require restarting system_server. ROM-specific optional
+                // hooks remain lazy inside setupStatusBar.
+                GlobalActionSystemServerHooks.setupGlobalActions(lpparam)
+                registry = created
+                created
+            }
+
+            // Unready snapshots must not decide business features. Always-on specs
+            // (preferenceKey null / isEnabled on an empty map) still install.
+            val installPrefs = if (prefReady) mPrefs else PrefMap()
+            activeRegistry.installAll(FeatureTarget.SYSTEM_SERVER, InstallPhase.SYSTEM_SERVER_STARTING, installPrefs)
+            if (SystemServerPrefLifecycle.shouldMarkCatchUpComplete(prefReady, currentBootstrapState())) {
+                catchUpDone = true
+            }
         }
-
-        val registerEndNanos = FeatureInstallMetrics.nowNanos()
-        val registerEndBytes = FeatureInstallMetrics.allocatedBytes()
-        FeatureInstallMetrics.recordCatalog(
-            label = "system-server/starting",
-            specCount = features.size + 1,
-            catalogStartNanos = catalogStartNanos,
-            catalogEndNanos = catalogEndNanos,
-            catalogStartBytes = catalogStartBytes,
-            catalogEndBytes = catalogEndBytes,
-            registerStartNanos = registerStartNanos,
-            registerEndNanos = registerEndNanos,
-            registerStartBytes = registerStartBytes,
-            registerEndBytes = registerEndBytes,
-        )
-
-        // PhoneWindowManager GlobalAction receiver is a cheap always-on transport.
-        // It must be installed at system_server start so later none → configured
-        // changes do not require restarting system_server. ROM-specific optional
-        // hooks remain lazy inside setupStatusBar.
-        GlobalActionSystemServerHooks.setupGlobalActions(lpparam)
-
-        registry.installAll(FeatureTarget.SYSTEM_SERVER, InstallPhase.SYSTEM_SERVER_STARTING, mPrefs)
     }
+
+    /**
+     * First [PreferenceBootstrap.State.LOADED] only: install features still
+     * [FeatureState.NOT_INSTALLED]. No-op once catch-up has run or when the snapshot
+     * is still empty/unavailable.
+     */
+    @JvmStatic
+    fun installPendingIfPrefsLoaded() {
+        synchronized(lock) {
+            if (!SystemServerPrefLifecycle.shouldRunCatchUp(catchUpDone, currentBootstrapState())) {
+                return
+            }
+            val activeRegistry = registry ?: return
+            activeRegistry.installAll(
+                FeatureTarget.SYSTEM_SERVER,
+                InstallPhase.SYSTEM_SERVER_STARTING,
+                MainModule.mPrefs,
+            )
+            catchUpDone = true
+        }
+    }
+
+    /**
+     * Posts [installPendingIfPrefsLoaded] onto [context]'s main looper.
+     *
+     * Preference invalidation arrives on a binder thread; hook installation must not
+     * run there.
+     */
+    @JvmStatic
+    fun scheduleCatchUp(context: Context) {
+        if (catchUpDone) return
+        val looper = context.mainLooper ?: return
+        Handler(looper).post { installPendingIfPrefsLoaded() }
+    }
+
+    private fun currentBootstrapState(): PreferenceBootstrap.State? =
+        MainModule.sPreferenceBootstrap?.getState()
 }
 
 internal class PackagePermissionsFeature(

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPrefLifecycle.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPrefLifecycle.kt
@@ -1,0 +1,24 @@
+package tv.withaibuild.customiuizer.mods.utils
+
+/**
+ * Pure gates for the system_server preference-install lifecycle.
+ *
+ * Business features are preference-gated at [FeatureInstallRegistry.installAll]. When the
+ * remote snapshot is not ready the installer feeds an empty map so those features stay
+ * [FeatureState.NOT_INSTALLED]. The first transition to [PreferenceBootstrap.State.LOADED]
+ * is allowed to run `installAll` again; already-installed features stay installed.
+ *
+ * Later preference toggles must not install new hooks — that remains a reboot/apply path.
+ */
+internal object SystemServerPrefLifecycle {
+
+    fun shouldMarkCatchUpComplete(
+        prefReady: Boolean,
+        state: PreferenceBootstrap.State?,
+    ): Boolean = prefReady && state == PreferenceBootstrap.State.LOADED
+
+    fun shouldRunCatchUp(
+        catchUpDone: Boolean,
+        state: PreferenceBootstrap.State?,
+    ): Boolean = !catchUpDone && state == PreferenceBootstrap.State.LOADED
+}

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPreferenceInvalidation.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPreferenceInvalidation.kt
@@ -57,12 +57,14 @@ object SystemServerPreferenceInvalidation {
 
                 if (intent.getBooleanExtra(EXTRA_BULK, false)) {
                     bootstrap.refreshRemoteKey(null)
+                    SystemServerInstaller.scheduleCatchUp(context)
                     return@guarded
                 }
 
                 val key = intent.getStringExtra(EXTRA_KEY)
                 if (key == null || !isValidKey(key)) return@guarded
                 bootstrap.refreshRemoteKey(key)
+                SystemServerInstaller.scheduleCatchUp(context)
             }
         }
     }

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemUiBootstrapCoordinator.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemUiBootstrapCoordinator.kt
@@ -13,8 +13,8 @@ import java.util.function.Supplier
  *
  * Owns the SystemUI-specific lifecycle that requires a live Context / ClassLoader:
  * initializer hook, fast-reboot receiver, status-bar setup, preference watch and the
- * 10-second restart guard.  MainModule stays focused on routing and delegates the
- * SystemUI branch to this object.
+ * 10-second restart diagnostic. The diagnostic does not skip the SystemUI catalog.
+ * MainModule stays focused on routing and delegates the SystemUI branch to this object.
  */
 object SystemUiBootstrapCoordinator {
 
@@ -119,24 +119,26 @@ object SystemUiBootstrapCoordinator {
         }
         evaluateGlobalActionStatusBarIfReady(lpparam, prefReady, globalActionStatusBarDone)
 
-        // 3. The 10s restart check is only allowed to skip the non-essential hooks below.
-        var skipNonEssential = false
+        // 3. The 10s window used to skip the entire SystemUI catalog, so a force-stop
+        // to apply settings looked like "hooks never installed". FeatureInstallState is
+        // process-scoped and installAll is idempotent, so the catalog always installs.
+        // No catalog feature is currently classified as restart-fighting; keep the
+        // timestamp read only as a diagnostic.
         if (mContext != null) {
             try {
                 val restartTime = Settings.System.getLong(mContext.contentResolver, "systemui_restart_time", 0L)
                 val currentTime = java.lang.System.currentTimeMillis()
-                if (currentTime - restartTime < restartThresholdMs) skipNonEssential = true
+                if (currentTime - restartTime < restartThresholdMs) {
+                    XposedHelpers.log(
+                        "SystemUiBootstrapCoordinator: SystemUI restarted within ${restartThresholdMs}ms, installing catalog"
+                    )
+                }
             } catch (oom: OutOfMemoryError) {
                 throw oom
             } catch (t: Throwable) {
                 FatalErrors.rethrowIfFatal(t)
                 XposedHelpers.log(t)
             }
-        }
-
-        if (skipNonEssential) {
-            HookDiagnostics.printSummaryForStage("onPackageReady")
-            return
         }
 
         SystemUiInstaller.install(lpparam, mPrefs)

--- a/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/feature/CommonPackageFeatures.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/mods/utils/feature/CommonPackageFeatures.kt
@@ -14,7 +14,7 @@ import tv.withaibuild.customiuizer.utils.PrefMap
 object CommonPackageFeatures {
     @JvmStatic
     fun hasEnabledFeature(prefs: PrefMap, packageName: String): Boolean =
-        StatusBarHeightFeature.evaluateEnabled(prefs) ||
+        StatusBarHeightFeature.evaluateEnabled(prefs, packageName) ||
             AlarmCompatFeature.evaluateEnabled(prefs, packageName)
 
     @JvmStatic
@@ -25,7 +25,7 @@ object CommonPackageFeatures {
             preferenceKey = "system_statusbarheight",
             target = FeatureTarget.ANY,
             phase = InstallPhase.PACKAGE_READY,
-            enabled = { prefs -> StatusBarHeightFeature.evaluateEnabled(prefs) },
+            enabled = { prefs -> StatusBarHeightFeature.evaluateEnabled(prefs, lpparam.packageName.orEmpty()) },
             factory = { StatusBarHeightFeature(lpparam, mPrefs) },
         ),
         LazyFeatureSpec(
@@ -52,11 +52,26 @@ internal class StatusBarHeightFeature(
     FeatureTarget.ANY,
 ) {
     companion object {
+        /**
+         * Resource replacement for `status_bar_height` only belongs in processes that
+         * actually read those dimens. Window height itself is applied in system_server
+         * via [StatusBarHeightInsetsFeature]. Installing the Resources/Theme trampoline
+         * in every app is wasted work and extra crash surface.
+         */
+        internal val RESOURCE_PACKAGES = setOf(
+            "android",
+            "com.android.systemui",
+            "com.miui.home",
+        )
+
         @JvmStatic
-        fun evaluateEnabled(prefs: PrefMap): Boolean = prefs.getInt("system_statusbarheight", 11) > 11
+        fun evaluateEnabled(prefs: PrefMap, packageName: String): Boolean =
+            prefs.getInt("system_statusbarheight", 11) > 11 &&
+                packageName in RESOURCE_PACKAGES
     }
 
-    override fun isEnabledCondition(prefs: PrefMap) = Companion.evaluateEnabled(prefs)
+    override fun isEnabledCondition(prefs: PrefMap) =
+        Companion.evaluateEnabled(prefs, packageName)
     override fun installHook() = ModsSystem.StatusBarHeightHook(lpparam)
 }
 

--- a/app/src/test/java/tv/withaibuild/customiuizer/installers/SystemUiInstallerTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/installers/SystemUiInstallerTest.kt
@@ -42,8 +42,12 @@ class SystemUiInstallerTest {
             coordinator.contains("currentTime - restartTime < restartThresholdMs")
         )
         assertTrue(
-            "SystemUiBootstrapCoordinator must delegate non-essential hooks to SystemUiInstaller",
+            "SystemUiBootstrapCoordinator must delegate the SystemUI catalog to SystemUiInstaller",
             coordinator.contains("SystemUiInstaller.install(lpparam, mPrefs)")
+        )
+        assertFalse(
+            "fast SystemUI restart must not skip the catalog installer",
+            coordinator.contains("if (skipNonEssential)")
         )
         assertTrue(
             "SystemUiBootstrapCoordinator must call FatalErrors.rethrowIfFatal in catch(Throwable)",

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/HotPathArgumentMaterializationTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/HotPathArgumentMaterializationTest.kt
@@ -40,7 +40,18 @@ class HotPathArgumentMaterializationTest {
 
         val windows = source("app/src/main/java/tv/withaibuild/customiuizer/mods/SystemWindowHooks.kt")
             .section("fun TempHideOverlayAppHook", "fun BetterPopupsAllowFloatHook")
-        assertAfter(windows, "WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY", "val args = XposedHelpers.getArgsArray(chain)")
+        assertTrue(
+            "overlay type gate must remain before any flag mutation",
+            windows.contains("WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY"),
+        )
+        assertTrue(
+            "TempHideOverlayAppHook must not materialize constructor args",
+            !windows.contains("getArgsArray"),
+        )
+
+        val helper = source("app/src/main/java/tv/withaibuild/customiuizer/mods/WindowSurfaceControlArgs.kt")
+            .section("fun interceptFlags", "private fun isAospLegacySurfaceConstructor")
+        assertAfter(helper, "transform(flags, windowType)", "val args = XposedHelpers.getArgsArray(chain)")
     }
 
     private fun assertAfter(text: String, earlier: String, later: String) {

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/WindowSurfaceControlArgsTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/WindowSurfaceControlArgsTest.kt
@@ -1,0 +1,47 @@
+package tv.withaibuild.customiuizer.mods
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WindowSurfaceControlArgsTest {
+
+    private val INT = Int::class.javaPrimitiveType!!
+
+    @Test
+    fun aospLegacyConstructor_flagsAtIndexFour() {
+        val types = arrayOf(
+            String::class.java,
+            INT, INT, INT, INT,
+            Any::class.java,
+            INT,
+            INT,
+        )
+        assertEquals(4, WindowSurfaceControlArgs.flagsIndex(types))
+        assertEquals(6, WindowSurfaceControlArgs.windowTypeIndex(types, 4))
+    }
+
+    @Test
+    fun miuiConstructor_flagsAtIndexTwo() {
+        val types = arrayOf(
+            Any::class.java,
+            String::class.java,
+            INT,
+            Any::class.java,
+            INT,
+        )
+        assertEquals(2, WindowSurfaceControlArgs.flagsIndex(types))
+        assertEquals(4, WindowSurfaceControlArgs.windowTypeIndex(types, 2))
+    }
+
+    @Test
+    fun aosp14BuilderConstructor_hasNoFlagsSlot() {
+        val types = arrayOf(
+            Any::class.java,
+            Any::class.java,
+            INT,
+            INT,
+        )
+        assertEquals(-1, WindowSurfaceControlArgs.flagsIndex(types))
+        assertEquals(-1, WindowSurfaceControlArgs.windowTypeIndex(types, -1))
+    }
+}

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/FeatureInstallRegistryTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/FeatureInstallRegistryTest.kt
@@ -80,6 +80,47 @@ class FeatureInstallRegistryTest {
     }
 
     @Test
+    fun installAll_skippedFeatureInstallsOnLaterEnabledSnapshot() {
+        var gate = false
+        val delayed = object : FeatureDefinition {
+            override val id = TestId("gated-late")
+            override val name = "gated-late"
+            override val preferenceKey: String? = "system_example"
+            override val target = FeatureTarget.SYSTEM_SERVER
+            override val phase = InstallPhase.SYSTEM_SERVER_STARTING
+            var installCalls = 0
+            override fun isEnabled(prefs: PrefMap): Boolean = gate
+            override fun install(): FeatureInstallResult {
+                installCalls++
+                return FeatureInstallResult.INSTALLED
+            }
+        }
+        val registry = FeatureInstallRegistry()
+        registry.register(delayed)
+
+        val first = registry.installAll(
+            FeatureTarget.SYSTEM_SERVER,
+            InstallPhase.SYSTEM_SERVER_STARTING,
+            PrefMap(),
+            collectResults = true,
+        )
+        assertEquals(FeatureInstallResult.SKIPPED, first.single())
+        assertEquals(0, delayed.installCalls)
+        assertEquals(FeatureState.NOT_INSTALLED, FeatureInstallState.get(delayed.id))
+
+        gate = true
+        val second = registry.installAll(
+            FeatureTarget.SYSTEM_SERVER,
+            InstallPhase.SYSTEM_SERVER_STARTING,
+            PrefMap(),
+            collectResults = true,
+        )
+        assertEquals(FeatureInstallResult.INSTALLED, second.single())
+        assertEquals(1, delayed.installCalls)
+        assertEquals(FeatureState.INSTALLED, FeatureInstallState.get(delayed.id))
+    }
+
+    @Test
     fun installAll_idempotent() {
         val registry = FeatureInstallRegistry()
         val f = DummyFeature("idempotent")

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/FeatureRegistryWiringTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/FeatureRegistryWiringTest.kt
@@ -28,7 +28,7 @@ class FeatureRegistryWiringTest {
         )
         assertTrue(
             "SystemServerInstaller should install SYSTEM_SERVER features at SYSTEM_SERVER_STARTING",
-            installMethod.contains("installAll(FeatureTarget.SYSTEM_SERVER, InstallPhase.SYSTEM_SERVER_STARTING, mPrefs)")
+            installMethod.contains("installAll(FeatureTarget.SYSTEM_SERVER, InstallPhase.SYSTEM_SERVER_STARTING")
         )
         assertFalse(
             "SystemServerInstaller install() should no longer call PackagePermissions.hook directly",

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/StatusBarInsetsRoutingTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/StatusBarInsetsRoutingTest.kt
@@ -57,6 +57,14 @@ class StatusBarInsetsRoutingTest {
     }
 
     @Test
+    fun resourceFeature_disabledForGenericPackageEvenWhenPrefSet() {
+        val feature = CommonPackageFeatures.all(fakePackageReadyParam("com.example.app"), PrefMap())
+            .find { it.id == StatusBarHeightFeatureId }
+        assertNotNull(feature)
+        assertFalse(feature!!.isEnabled(PrefMap().apply { put("system_statusbarheight", 40) }))
+    }
+
+    @Test
     fun insetsFeature_disabledWhenPrefIsDefault() {
         val feature = SystemServerFeatures.all(fakeSystemServerStartingParam())
             .find { it.id == StatusBarHeightInsetsFeatureId }

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPrefLifecycleTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPrefLifecycleTest.kt
@@ -1,0 +1,64 @@
+package tv.withaibuild.customiuizer.mods.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SystemServerPrefLifecycleTest {
+
+    @Test
+    fun catchUpCompletesOnlyOnLoadedSnapshot() {
+        assertTrue(
+            SystemServerPrefLifecycle.shouldMarkCatchUpComplete(
+                prefReady = true,
+                state = PreferenceBootstrap.State.LOADED,
+            ),
+        )
+        assertFalse(
+            SystemServerPrefLifecycle.shouldMarkCatchUpComplete(
+                prefReady = true,
+                state = PreferenceBootstrap.State.VALID_EMPTY,
+            ),
+        )
+        assertFalse(
+            SystemServerPrefLifecycle.shouldMarkCatchUpComplete(
+                prefReady = false,
+                state = PreferenceBootstrap.State.LOADED,
+            ),
+        )
+        assertFalse(
+            SystemServerPrefLifecycle.shouldMarkCatchUpComplete(
+                prefReady = false,
+                state = PreferenceBootstrap.State.UNAVAILABLE,
+            ),
+        )
+    }
+
+    @Test
+    fun catchUpRunsOnceWhenFirstLoaded() {
+        assertTrue(
+            SystemServerPrefLifecycle.shouldRunCatchUp(
+                catchUpDone = false,
+                state = PreferenceBootstrap.State.LOADED,
+            ),
+        )
+        assertFalse(
+            SystemServerPrefLifecycle.shouldRunCatchUp(
+                catchUpDone = true,
+                state = PreferenceBootstrap.State.LOADED,
+            ),
+        )
+        assertFalse(
+            SystemServerPrefLifecycle.shouldRunCatchUp(
+                catchUpDone = false,
+                state = PreferenceBootstrap.State.VALID_EMPTY,
+            ),
+        )
+        assertFalse(
+            SystemServerPrefLifecycle.shouldRunCatchUp(
+                catchUpDone = false,
+                state = PreferenceBootstrap.State.UNAVAILABLE,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPreferenceInvalidationTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPreferenceInvalidationTest.kt
@@ -168,6 +168,23 @@ class SystemServerPreferenceInvalidationTest {
         assertEquals(dispatchedByListener, dispatched)
     }
 
+    @Test
+    fun firstLoadedCatchUpIsScheduledFromInvalidationReceiver() {
+        val source = java.io.File("app/src/main/java/tv/withaibuild/customiuizer/mods/utils/SystemServerPreferenceInvalidation.kt")
+            .let { file ->
+                var directory = java.io.File(System.getProperty("user.dir").orEmpty()).absoluteFile
+                while (!java.io.File(directory, file.path).isFile) {
+                    directory = directory.parentFile
+                        ?: error("Repository root not found")
+                }
+                java.io.File(directory, file.path).readText()
+            }
+        assertTrue(
+            "invalidation must schedule system_server catch-up after a trusted refresh",
+            source.contains("SystemServerInstaller.scheduleCatchUp(context)"),
+        )
+    }
+
     private fun primed(key: String, value: Any): FakeSharedPreferences {
         val fake = FakeSharedPreferences()
         fake.put(key, value)

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/feature/CommonPackageFastGateTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/feature/CommonPackageFastGateTest.kt
@@ -21,10 +21,13 @@ class CommonPackageFastGateTest {
     }
 
     @Test
-    fun statusBarHeightEnablesCommonFeatureForEveryPackage() {
+    fun statusBarHeightEnablesCommonFeatureOnlyForResourcePackages() {
         val prefs = PrefMap().apply { put("system_statusbarheight", 12) }
 
-        assertTrue(CommonPackageFeatures.hasEnabledFeature(prefs, "com.example.app"))
+        assertTrue(CommonPackageFeatures.hasEnabledFeature(prefs, "android"))
+        assertTrue(CommonPackageFeatures.hasEnabledFeature(prefs, "com.android.systemui"))
+        assertTrue(CommonPackageFeatures.hasEnabledFeature(prefs, "com.miui.home"))
+        assertFalse(CommonPackageFeatures.hasEnabledFeature(prefs, "com.example.app"))
     }
 
     @Test

--- a/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/feature/SystemServerFeaturesWiringTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/mods/utils/feature/SystemServerFeaturesWiringTest.kt
@@ -47,7 +47,15 @@ class SystemServerFeaturesWiringTest {
         )
         assertTrue(
             "install() should call installAll for SYSTEM_SERVER at SYSTEM_SERVER_STARTING",
-            installMethod.contains("installAll(FeatureTarget.SYSTEM_SERVER, InstallPhase.SYSTEM_SERVER_STARTING, mPrefs)")
+            installMethod.contains("installAll(FeatureTarget.SYSTEM_SERVER, InstallPhase.SYSTEM_SERVER_STARTING"),
+        )
+        assertTrue(
+            "unready prefs must not decide business features against the live snapshot",
+            installMethod.contains("if (prefReady) mPrefs else PrefMap()"),
+        )
+        assertTrue(
+            "first LOADED snapshot must catch up NOT_INSTALLED features",
+            source.contains("installPendingIfPrefsLoaded"),
         )
     }
 


### PR DESCRIPTION
Prerelease candidate for `r14.20.9`. Does not publish LSPosed.

## Behavior (unchanged by the CI follow-up)
- `system_server`: skip gated features until prefs are `LOADED`; first `LOADED` installs only `NOT_INSTALLED`.
- Fast SystemUI restart no longer skips the catalog installer.
- WindowManager hot-path ClassCast/NPE isolated; constructor flags resolved by type, not `args[2]`.
- Status-bar height resource hooks limited to `android`, SystemUI, and `com.miui.home`.

## CI fix on top of the tagged SHA
Tag `r14.20.9` (`4259c312`) failed [A14 Full CI](https://github.com/tomthenpc/customiuizer-a14/actions/runs/33960178109) at Python tool tests:
1. architecture scan required `registry.installAll(` / `registry.register(` — locals were named `activeRegistry` / `created`
2. `PackagePermissionsFeatureId` dropped from the direct FeatureDefinition parser for the same reason
3. `HotPathArgumentMaterializationTest` still expected `getArgsArray` inside `TempHideOverlayAppHook`

Follow-up `52bda702` is a rename + test update only. Lifecycle and hook behavior are the same.

## Gates
- Fast CI runs on this PR.
- Full CI must pass on this SHA (or a retag) before treating the GitHub prerelease as shippable. The existing tag still points at the failing SHA and is not moved here.