### PR TITLE
r14.21.4: Neutral Grouped settings surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,45 +2,31 @@
 
 English | [简体中文](CHANGELOG_CN.md)
 
-## r14.21.3 — 2026-09-06
+## r14.21.4 — 2026-09-06
 
 Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.
 
+This is the only r14.21.* release. It keeps the grouped-settings chrome and the notification-channel routing, and maps surfaces to the low-chroma ends of the system palette.
+
 ### Settings UI
 
-- Grouped lists, search, app/Wi-Fi/Bluetooth pickers, sortable actions, overflow menus, dialogs, and About share one 12 dp corner radius.
-- Two surfaces only: the page and the menu card. Light uses Neutral1 200 behind Neutral1 10 cards; dark uses Neutral1 1000 behind Neutral1 700 cards. Wallpaper remains the color source.
-- Tap and long-press are discrete overlays (no ripple), with long-press slightly stronger, clipped inside the card corners.
+- Preference lists, search, app / Wi-Fi / Bluetooth pickers, sortable actions, overflow menus, dialogs, and About use grouped inset cards.
+- One 10 dp corner radius. Category titles are sentence case, not ALL CAPS. Home-page category icons stay off. The 1 dp toolbar hairline is gone.
+- Two surfaces only. Light: Neutral1 50 page behind Neutral1 10 cards. Dark: Neutral1 1000 page behind Neutral1 900 cards. Wallpaper supplies those low-chroma ends; accent stays on switches and checked state.
+- Separators are 12% black / 15% white hairlines, not a tinted Neutral2 stroke.
+- Title / summary / category type is 17 / 13 / 13 sp.
+- Tap and long-press are discrete overlays (no ripple), long-press slightly stronger, clipped inside the card corners.
 
 ### Notifications
 
 - Open channel settings uses `Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS` with the live notification, not a SubSettings fragment.
 - Notification importance is wired to both ChannelNotificationSettings implementations and writes the value back.
-- The extra notification-row actions keep the ROM's per-side margin so the sixth action stays on screen.
+- Extra notification-row actions keep the ROM's per-side margin so the sixth action stays on screen.
 
 ### Artifact Information
 
-- APK: `CustoMIUIzer-A14-r14.21.3.apk`
-- versionCode / versionName: `210 / r14.21.3`
-
----
-
-## r14.21.2 — 2026-09-06
-
-Targeting HyperOS 1 / Android 14 (SDK 34), `arm64-v8a`, libxposed API 101/102.
-
-### Settings UI
-
-- Preference lists and About use grouped inset cards.
-- Category titles use sentence case instead of ALL CAPS.
-- The 1 dp line under the toolbar is removed.
-- Grouped cards, search results, overflow menus, and dialogs share system dynamic surface and outline tokens. The wallpaper palette is the color source.
-- Title, summary, and category type sizes follow a Settings-like hierarchy.
-
-### Artifact Information
-
-- APK: `CustoMIUIzer-A14-r14.21.2.apk`
-- versionCode / versionName: `209 / r14.21.2`
+- APK: `CustoMIUIzer-A14-r14.21.4.apk`
+- versionCode / versionName: `211 / r14.21.4`
 
 ---
 

--- a/CHANGELOG_CN.md
+++ b/CHANGELOG_CN.md
@@ -2,45 +2,31 @@
 
 [English](CHANGELOG.md) | 简体中文
 
-## r14.21.3 — 2026-09-06
+## r14.21.4 — 2026-09-06
 
 面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。
 
+r14.21.* 只保留这一版。分组设置界面和通知频道路由一并保留，表面色改走系统色板的低彩度两端。
+
 ### 设置界面
 
-- 分组列表、搜索、应用/Wi-Fi/蓝牙选择、可排序动作、右上角菜单、对话框和关于页统一 12 dp 圆角。
-- 页面和菜单只保留两套表面色：浅色 Neutral1 200 底 + Neutral1 10 卡片，深色 Neutral1 1000 底 + Neutral1 700 卡片。颜色仍来自壁纸色板。
-- 点按和长按改为实色叠加（无水波纹），长按略深，并裁进卡片圆角内。
+- 偏好列表、搜索、应用 / Wi-Fi / 蓝牙选择、可排序动作、右上角菜单、对话框和关于页使用分组内嵌卡片。
+- 统一 10 dp 圆角。分类标题为句首大写，不再使用全大写。首页分类图标不加。标题栏下方 1 dp 细线去掉。
+- 只保留两套表面色。浅色：Neutral1 50 页底 + Neutral1 10 卡片。深色：Neutral1 1000 页底 + Neutral1 900 卡片。壁纸只给这些低彩度两端上色，强调色只用在开关和选中态。
+- 分隔线为 12% 黑 / 15% 白发丝，不再使用染色的 Neutral2。
+- 标题 / 摘要 / 分类字号为 17 / 13 / 13 sp。
+- 点按和长按为实色叠加（无水波纹），长按略深，并裁进卡片圆角内。
 
 ### 通知
 
-- 「打开频道设置」改为系统公开 `ACTION_CHANNEL_NOTIFICATION_SETTINGS`，按当前通知打开，不再走 SubSettings fragment。
+- 「打开频道设置」使用系统公开 `ACTION_CHANNEL_NOTIFICATION_SETTINGS`，按当前通知打开，不再走 SubSettings fragment。
 - 「通知重要性」同时挂新旧两套 ChannelNotificationSettings，并把档位写回通知系统。
 - 扩展通知菜单恢复 ROM 单侧边距，避免第六项「浮窗」被裁切。
 
 ### 产物信息
 
-- APK：`CustoMIUIzer-A14-r14.21.3.apk`
-- versionCode / versionName：`210 / r14.21.3`
-
----
-
-## r14.21.2 — 2026-09-06
-
-面向 HyperOS 1 / Android 14（SDK 34）、`arm64-v8a`、libxposed API 101/102。
-
-### 设置界面
-
-- 偏好列表与关于页使用分组内嵌卡片。
-- 分类标题改为句首大写，不再使用全大写。
-- 去掉标题栏下方 1 dp 细线。
-- 分组卡片、搜索结果、右上角菜单与对话框共用系统动态色的 surface / outline token，颜色来源为壁纸色板。
-- 标题、摘要与分类字号按设置页层级对齐。
-
-### 产物信息
-
-- APK：`CustoMIUIzer-A14-r14.21.2.apk`
-- versionCode / versionName：`209 / r14.21.2`
+- APK：`CustoMIUIzer-A14-r14.21.4.apk`
+- versionCode / versionName：`211 / r14.21.4`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CustoMIUIzer A14 是面向 **HyperOS 1 / Android 14（SDK 34）** 的系统界面与交互定制模块，基于 CustoMIUIzer 项目持续维护。它使用独立包名和版本线，不是上游官方版本。
 
-- 当前正式版：`r14.21.3`
+- 当前正式版：`r14.21.4`
 - 应用 ID：`tv.withaibuild.customiuizer.r14`
 - 源码仓库：<https://github.com/tomthenpc/customiuizer-a14>
 - 用户下载：<https://github.com/Xposed-Modules-Repo/tv.withaibuild.customiuizer.r14/releases>

--- a/README_EN.md
+++ b/README_EN.md
@@ -4,7 +4,7 @@
 
 CustoMIUIzer A14 is a system UI and interaction customization module maintained for **HyperOS 1 / Android 14 (SDK 34)**. It has an independent package and release line and is not an official upstream release.
 
-- Current release: `r14.21.3`
+- Current release: `r14.21.4`
 - Application ID: `tv.withaibuild.customiuizer.r14`
 - Source: <https://github.com/tomthenpc/customiuizer-a14>
 - User downloads: <https://github.com/Xposed-Modules-Repo/tv.withaibuild.customiuizer.r14/releases>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,8 +34,8 @@ if (officialRelease) {
     }
 }
 
-val lastVersion = 210
-val lastVersionName = "r14.21.3"
+val lastVersion = 211
+val lastVersionName = "r14.21.4"
 
 fun resolveBuildRevision(): String {
     val prop = project.findProperty("buildRevision")?.toString()

--- a/app/src/main/java/tv/withaibuild/customiuizer/PreferenceGroupChrome.kt
+++ b/app/src/main/java/tv/withaibuild/customiuizer/PreferenceGroupChrome.kt
@@ -298,7 +298,6 @@ internal class PreferenceGroupDecoration(
         dividerInset = res.getDimensionPixelSize(R.dimen.preference_item_child_padding)
         fillPaint.color = parent.context.getColor(R.color.color_surface_container)
         dividerPaint.color = parent.context.getColor(R.color.color_outline_variant)
-        dividerPaint.alpha = 102
         paintsReady = true
     }
 

--- a/app/src/main/res/drawable/pref_search_row_middle.xml
+++ b/app/src/main/res/drawable/pref_search_row_middle.xml
@@ -7,7 +7,6 @@
 	</item>
 	<item android:drawable="@drawable/list_item_bg" />
 	<item
-		android:alpha="0.4"
 		android:gravity="bottom"
 		android:left="@dimen/preference_item_child_padding"
 		android:right="@dimen/preference_item_child_padding">

--- a/app/src/main/res/drawable/pref_search_row_top.xml
+++ b/app/src/main/res/drawable/pref_search_row_top.xml
@@ -10,7 +10,6 @@
 	</item>
 	<item android:drawable="@drawable/list_item_bg" />
 	<item
-		android:alpha="0.4"
 		android:gravity="bottom"
 		android:left="@dimen/preference_item_child_padding"
 		android:right="@dimen/preference_item_child_padding">

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<color name="color_window_background">@android:color/system_neutral1_1000</color>
-	<color name="color_surface_container">@android:color/system_neutral1_700</color>
+	<color name="color_surface_container">@android:color/system_neutral1_900</color>
 	<color name="color_surface_variant">@android:color/system_neutral2_700</color>
-	<color name="color_on_surface">@android:color/system_neutral1_50</color>
+	<color name="color_on_surface">@android:color/system_neutral1_100</color>
 	<color name="color_on_surface_variant">@android:color/system_neutral1_200</color>
-	<color name="color_outline_variant">@android:color/system_neutral2_600</color>
+	<color name="color_outline_variant">#26FFFFFF</color>
 	<color name="about_divider">@color/color_outline_variant</color>
 	<color name="highlight_normal_light">@android:color/system_accent1_200</color>
 
 	<color name="preference_category_text_color">@color/color_on_surface_variant</color>
-	<color name="preference_primary_text_color">@android:color/system_neutral1_50</color>
+	<color name="preference_primary_text_color">@android:color/system_neutral1_100</color>
 	<color name="preference_primary_text_color_pressed">@color/color_on_surface</color>
 	<color name="preference_secondary_text_color">@android:color/system_neutral2_200</color>
 	<color name="preference_secondary_text_color_pressed">@color/color_on_surface_variant</color>
@@ -18,7 +18,7 @@
 
 	<color name="hint_edit_text_color">@color/color_on_surface_variant</color>
 
-	<color name="list_item_bg_color_pressed">#29ffffff</color>
-	<color name="list_item_bg_color_longpress">#3dffffff</color>
+	<color name="list_item_bg_color_pressed">#14FFFFFF</color>
+	<color name="list_item_bg_color_longpress">#24FFFFFF</color>
 
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 	<color name="ic_launcher_background">#ff424a60</color>
-	<!-- Two surfaces only: grouped page vs menu card. System wallpaper palette. -->
-	<color name="color_window_background">@android:color/system_neutral1_200</color>
+	<!-- Two surfaces: grouped page vs menu card. Low-chroma ends of the system palette. -->
+	<color name="color_window_background">@android:color/system_neutral1_50</color>
 	<color name="color_surface_container">@android:color/system_neutral1_10</color>
 	<color name="color_surface_variant">@android:color/system_neutral2_100</color>
-	<color name="color_on_surface">@android:color/system_neutral1_1000</color>
+	<color name="color_on_surface">@android:color/system_neutral1_900</color>
 	<color name="color_on_surface_variant">@android:color/system_neutral1_700</color>
-	<color name="color_outline_variant">@android:color/system_neutral2_300</color>
+	<color name="color_outline_variant">#1F000000</color>
 	<color name="about_divider">@color/color_outline_variant</color>
 	<color name="highlight_normal_light">@android:color/system_accent1_600</color>
 
 	<color name="preference_category_text_color">@color/color_on_surface_variant</color>
-	<color name="preference_primary_text_color">@android:color/system_neutral1_1000</color>
+	<color name="preference_primary_text_color">@android:color/system_neutral1_900</color>
 	<color name="preference_primary_text_color_disable">@color/preference_primary_text_disable</color>
 	<color name="preference_primary_text_color_pressed">@color/color_on_surface</color>
-	<color name="preference_secondary_text_color">@android:color/system_neutral2_800</color>
+	<color name="preference_secondary_text_color">@android:color/system_neutral2_700</color>
 	<color name="preference_secondary_text_color_disable">@color/preference_primary_text_disable</color>
 	<color name="preference_secondary_text_color_pressed">@color/color_on_surface_variant</color>
 	<color name="preference_secondary_text_color_checked">@color/highlight_normal_light</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,9 +6,9 @@
 	<dimen name="preference_item_padding_bottom">12dp</dimen>
 	<dimen name="preference_item_child_padding">16dp</dimen>
 	<dimen name="preference_group_inset">16dp</dimen>
-	<dimen name="preference_group_radius">12dp</dimen>
+	<dimen name="preference_group_radius">10dp</dimen>
 	<dimen name="preference_group_gap">12dp</dimen>
-	<dimen name="preference_group_header_bottom">6dp</dimen>
+	<dimen name="preference_group_header_bottom">8dp</dimen>
 	<dimen name="preference_group_header_padding">32dp</dimen>
 	<dimen name="preference_group_divider_height">1dp</dimen>
 	<dimen name="preference_summary_padding_right">10dp</dimen>

--- a/app/src/test/java/tv/withaibuild/customiuizer/PreferenceGroupChromeTest.kt
+++ b/app/src/test/java/tv/withaibuild/customiuizer/PreferenceGroupChromeTest.kt
@@ -230,6 +230,7 @@ class PreferenceGroupChromeWiringTest {
         assertTrue(card.contains("@color/color_surface_container"))
         assertTrue(decoration.contains("R.color.color_surface_container"))
         assertTrue(decoration.contains("R.color.color_outline_variant"))
+        assertFalse(decoration.contains("dividerPaint.alpha"))
         assertFalse(decoration.contains("R.color.color_surface_variant"))
         assertFalse(decoration.contains("R.color.about_divider"))
     }
@@ -241,10 +242,14 @@ class PreferenceGroupChromeWiringTest {
             assertTrue(source.contains("color_surface_container"))
             assertTrue(source.contains("color_outline_variant"))
         }
-        assertTrue(lightColors.contains("color_window_background\">@android:color/system_neutral1_200"))
+        assertTrue(lightColors.contains("color_window_background\">@android:color/system_neutral1_50"))
         assertTrue(lightColors.contains("color_surface_container\">@android:color/system_neutral1_10"))
         assertTrue(nightColors.contains("color_window_background\">@android:color/system_neutral1_1000"))
-        assertTrue(nightColors.contains("color_surface_container\">@android:color/system_neutral1_700"))
+        assertTrue(nightColors.contains("color_surface_container\">@android:color/system_neutral1_900"))
+        assertTrue(lightColors.contains("color_outline_variant\">#1F000000"))
+        assertTrue(nightColors.contains("color_outline_variant\">#26FFFFFF"))
+        assertTrue(lightColors.contains("list_item_bg_color_pressed\">#14000000"))
+        assertTrue(nightColors.contains("list_item_bg_color_pressed\">#14FFFFFF"))
         assertTrue(lightColors.contains("list_item_bg_color_longpress"))
         assertTrue(nightColors.contains("list_item_bg_color_longpress"))
     }
@@ -267,12 +272,16 @@ class PreferenceGroupChromeWiringTest {
         assertTrue(selected.contains("@color/list_item_bg_color_longpress"))
         val searchSingle = source("app/src/main/res/drawable/pref_search_row_single.xml")
         val searchTop = source("app/src/main/res/drawable/pref_search_row_top.xml")
+        val searchMiddle = source("app/src/main/res/drawable/pref_search_row_middle.xml")
         val searchBottom = source("app/src/main/res/drawable/pref_search_row_bottom.xml")
-        for (row in listOf(searchSingle, searchTop, searchBottom)) {
+        for (row in listOf(searchSingle, searchTop, searchMiddle, searchBottom)) {
             assertTrue(row.contains("<layer-list"))
             assertTrue(row.contains("@drawable/list_item_bg"))
-            assertTrue(row.contains("@dimen/preference_group_radius"))
+            assertFalse(row.contains("android:alpha"))
             assertFalse(row.contains("<ripple"))
+        }
+        for (row in listOf(searchSingle, searchTop, searchBottom)) {
+            assertTrue(row.contains("@dimen/preference_group_radius"))
         }
         assertTrue(decoration.contains("applyGroupedListRow"))
         assertTrue(searchAdapter.contains("applyGroupedListRow"))
@@ -300,9 +309,10 @@ class PreferenceGroupChromeWiringTest {
         assertTrue(categoryEx.contains("preference_group_header_padding"))
         val dimens = source("app/src/main/res/values/dimens.xml")
         assertTrue(dimens.contains("preference_group_header_padding\">32dp"))
+        assertTrue(dimens.contains("preference_group_header_bottom\">8dp"))
         assertTrue(dimens.contains("normal_text_size\">17sp"))
         assertTrue(dimens.contains("secondary_text_size\">13sp"))
-        assertTrue(dimens.contains("preference_group_radius\">12dp"))
+        assertTrue(dimens.contains("preference_group_radius\">10dp"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Map grouped settings page/card fills to the low-chroma ends of the system palette (`N1_50`/`N1_10` light, `N1_1000`/`N1_900` dark).
- Use 12% black / 15% white hairline separators and a unified 10 dp corner radius.
- Keep grouped chrome and public notification-channel Intent routing; fold r14.21.2 / r14.21.3 notes into r14.21.4.

## Test plan
- [x] `testDebugUnitTest` 2401 / 0 fail / 0 error / 2 skip
- [x] `lintDebug` 0 Error / 0 Fatal
- [x] static verify gates (PrefMap 0, hotpath 13, cleanliness, invariants, release metadata)
- [ ] Device wallpaper chroma check after install